### PR TITLE
Refactoring to remove :not selector; replace with a text modifier class

### DIFF
--- a/src/scss/field-errors.scss
+++ b/src/scss/field-errors.scss
@@ -1,9 +1,9 @@
 @include oFtFormsPlaceholderOptionalSelector('%o-ft-forms__field--error, %o-ft-forms__label--select--error, %o-ft-forms__label--textarea--error',
-  '.o-ft-forms--error .o-ft-forms__field:not([type="checkbox"]):not([type="radio"]), 
+  '.o-ft-forms--error .o-ft-forms__field--text, 
   .o-ft-forms--error .o-ft-forms__field--select, 
   .o-ft-forms--error .o-ft-forms__field--textarea') {
     border-color: oColorsGetColorFor(o-ft-forms-field-invalid, border);
-    color: oColorsGetColorFor(fo-ft-forms-field-invalid o-ft-forms-field-standard, text);
+    color: oColorsGetColorFor(o-ft-forms-field-invalid o-ft-forms-field-standard, text);
 }
 
 @include oFtFormsPlaceholderOptionalSelector('%o-ft-forms__errortext', '.o-ft-forms__errortext') {

--- a/src/scss/field-valid.scss
+++ b/src/scss/field-valid.scss
@@ -1,5 +1,5 @@
 @include oFtFormsPlaceholderOptionalSelector('%o-ft-forms__field--valid, %o-ft-forms__label--select--valid, %o-ft-forms__label--textarea--valid',
-  '.o-ft-forms--valid .o-ft-forms__field:not([type="checkbox"]):not([type="radio"]), 
+  '.o-ft-forms--valid .o-ft-forms__field--text, 
   .o-ft-forms--valid .o-ft-forms__field--select, 
   .o-ft-forms--valid .o-ft-forms__field--textarea') {
   border-color: oColorsGetColorFor(o-ft-forms-field-valid, border);

--- a/src/scss/fields.scss
+++ b/src/scss/fields.scss
@@ -26,7 +26,7 @@
   '%o-ft-forms__field,
   %o-ft-forms__label--select,
   %o-ft-forms__label--textarea',
-  '.o-ft-forms__field:not([type="checkbox"]):not([type="radio"]),
+  '.o-ft-forms__field--text,
   .o-ft-forms__field--select,
   .o-ft-forms__field--textarea'
 ) {
@@ -37,7 +37,7 @@
   '%o-ft-forms__field:disabled,
   %o-ft-forms__label--select:disabled,
   %o-ft-forms__label--textarea:disabled',
-  '.o-ft-forms__field:disabled:not([type="checkbox"]):not([type="radio"]),
+  '.o-ft-forms__field--text:disabled,
   .o-ft-forms__field--select:disabled,
   .o-ft-forms__field--textarea:disabled') {
     @include commonFieldDisabled();
@@ -47,7 +47,7 @@
   '%o-ft-forms__field:focus,
   %o-ft-forms__label--select:focus,
   %o-ft-forms__label--textarea:focus',
-  '.o-ft-forms__field:focus:not([type="checkbox"]):not([type="radio"]),
+  '.o-ft-forms__field--text:focus,
   .o-ft-forms__field--select:focus,
   .o-ft-forms__field--textarea:focus') {
     @include commonFieldFocus();

--- a/src/scss/prefix-suffix.scss
+++ b/src/scss/prefix-suffix.scss
@@ -9,7 +9,7 @@
 
 @include oFtFormsPlaceholderOptionalSelector(
   '%o-ft-forms__field--affixed',
-  '.o-ft-forms__affix-wrapper .o-ft-forms__field:not([type="checkbox"]):not([type="radio"]),
+  '.o-ft-forms__affix-wrapper .o-ft-forms__field--text,
   .o-ft-forms__affix-wrapper .o-ft-forms__field--select'
 ) {
   display: table-cell;
@@ -18,7 +18,7 @@
 
 @include oFtFormsPlaceholderOptionalSelector(
   '%o-ft-forms__field--prefixed',
-  '.o-ft-forms__affix-wrapper .o-ft-forms__field:not([type="checkbox"]):not([type="radio"]):first-child,
+  '.o-ft-forms__affix-wrapper .o-ft-forms__field--text:first-child,
   .o-ft-forms__affix-wrapper .o-ft-forms__field--select:first-child'
 ) {
   border-top-left-radius: $_o-ft-forms-field-borderradius;
@@ -27,7 +27,7 @@
 
 @include oFtFormsPlaceholderOptionalSelector(
   '%o-ft-forms__field-suffixed',
-  '.o-ft-forms__affix-wrapper .o-ft-forms__field:not([type="checkbox"]):not([type="radio"]):last-child,
+  '.o-ft-forms__affix-wrapper .o-ft-forms__field--text:last-child,
   .o-ft-forms__affix-wrapper .o-ft-forms__field--select:last-child'
 ) {
   border-top-right-radius: $_o-ft-forms-field-borderradius;


### PR DESCRIPTION
@triblondon, @jamesnicholls 
https://github.com/Financial-Times/o-ft-forms/issues/58
Note: this change would be non-backwards compatible.
