### PR TITLE
Removing width:100% from commonField; creating a new class for full width

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -5,7 +5,6 @@
   border: $_o-ft-forms-fieldborder;
   border-radius: $_o-ft-forms-field-borderradius;
   padding: $_o-ft-form-field-big-padding-topbottom $_o-ft-form-field-big-padding-leftright;
-  width: 100%;
   background-color: oColorsGetColorFor(o-ft-forms-field-standard, background);
   color: oColorsGetColorFor(o-ft-forms-field-standard, text);
   font-family: oFontsGetFontFamilyWithFallbacks(BentonSans);

--- a/src/scss/fields.scss
+++ b/src/scss/fields.scss
@@ -77,6 +77,14 @@
     vertical-align: top;
 }
 
+@include oFtFormsPlaceholderOptionalSelector(
+  '%o-ft-forms__field--full-width',
+  '.o-ft-forms__field--full-width'
+) {
+    width: 100%;
+}
+
+
 // TBC - This is to hide Chrome's style for autocompleted fields
 @include oFtFormsPlaceholderOptionalSelector(
   '%o-ft-forms__field:-webkit-autofill',


### PR DESCRIPTION
@triblondon , @jamesnicholls 
Note: This change is non-backwards compatible.
https://github.com/Financial-Times/o-ft-forms/issues/58
