### PR TITLE
o-colors 2.4.7 no longer compiles, but it is also not needed for this…

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -13,7 +13,6 @@
             "template": "demos/src/real-life.mustache",
             "bodyClasses": "o-colors-page-background demo-real-life",
             "dependencies": [
-                "o-colors@^2.4.7",
                 "o-fonts@^1.4.0",
                 "o-tabs@^1.4.2",
                 "o-buttons@^2.0.4",


### PR DESCRIPTION
… demo so the simplest fix is to remove it as a dependency