### PR TITLE
Add form validation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 .sass-cache/
 bower_components/
 build/
+coverage/
 demos/local/
 node_modules/
 /bin
 /.classpath
 /.project
 .DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # o-forms [![CircleCI](https://circleci.com/gh/Financial-Times/o-forms.png?style=shield&circle-token=8d39afee1e3c3b1f586770034db9673b791cb4f8)](https://circleci.com/gh/Financial-Times/o-forms)
 
-FT-branded styles for commonly used form elements.
+FT-branded styles for form elements.
 
-Upgrading from v1.x.x or v2.x.x? [Follow these instructions](#upgrade-to-v3).
-Upgrading from v0.x.x? [Follow these instructions](#upgrade-to-v1).
+- [Usage](#usage)
+	- [Markup](#markup)
+	- [Sass](#sass)
+- [Troubleshooting](#troubleshooting)
+- [Migration guide](#migration-guide)
+- [Contact](#contact)
+- [Licence](#licence)
+
 
 ## Usage
 
-### Basic form field structure
+### Markup
 
 Each form field is made up of at least 3 elements:
 
@@ -24,7 +30,7 @@ Each form field is made up of at least 3 elements:
 
 [Text input examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/text-inputs.html)
 
-### Select boxes
+#### Select boxes
 
 ```html
 <div class="o-forms">
@@ -40,7 +46,7 @@ Each form field is made up of at least 3 elements:
 
 [Select boxes examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/select-boxes.html)
 
-### Textareas
+#### Textareas
 
 ```html
 <div class="o-forms">
@@ -51,7 +57,7 @@ Each form field is made up of at least 3 elements:
 
 [Textarea examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/textareas.html)
 
-### Checkboxes and radio controls
+#### Checkboxes and radio controls
 
 Couple the checkboxes and radio controls with a label to obtain the desired styles:
 
@@ -76,7 +82,7 @@ Couple the checkboxes and radio controls with a label to obtain the desired styl
 [Radio control examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/radios.html)
 [Checkbox examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/checkboxes.html)
 
-### Validation states
+#### Validation states
 
 Validation styles are applied by adding `.o-forms--error` or `.o-forms--valid` to the field's containing element (typically, `.o-forms`). Child `.o-forms__label`, `.o-forms__text`, `.o-forms__select`, `.o-forms__checkbox`, `.o-forms__radio`, `.o-forms__textarea` elements will be styled appropriately.
 
@@ -91,7 +97,7 @@ Example HTML:
 </div>
 ```
 
-### Wrappers
+#### Wrappers
 
 You can wrap a group of fields to highlight it or show it is not valid:
 
@@ -110,7 +116,7 @@ You can wrap a group of fields to highlight it or show it is not valid:
 
 [Wrapper examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/wrappers.html)
 
-### Messages
+#### Messages
 
 ```html
 <div class="o-forms__message">
@@ -124,7 +130,7 @@ You can wrap a group of fields to highlight it or show it is not valid:
 
 [Messages examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/messages.html)
 
-### Prefixes and suffixes
+#### Prefixes and suffixes
 
 Prefixes and suffixes are used for prepending or appending static text to a form control. The form control should be wrapped in a block-level element with a class of `.o-forms__affix-wrapper`. Prefixes (defined by `.o-forms__prefix`) and suffixes (defined by `.o-forms__suffix`) can then be prepended/appended to this wrapper element.
 
@@ -142,7 +148,7 @@ Prefixes and suffixes are used for prepending or appending static text to a form
 
 [Prefixes and suffixes examples](https://origami-build.ft.com/v2/files/o-forms@%5E1/demos/prefix-suffix.html)
 
-### "unskin" a form element
+#### "unskin" a form element
 
 Add the class `o-forms--unskin` to a text field to reset its appearance while keeping its vertical structure and other field properties (editable, focusable).
 
@@ -160,7 +166,10 @@ Properties of the `o-forms--unskin` class:
 - editable
 - focusable
 
-### Silent mode
+
+### Sass
+
+#### Silent mode
 
 In silent mode `o-forms` provides mixins for each set of form fields as well as some mixins to output basic form styles in one large chunk.
 
@@ -180,7 +189,7 @@ The `oForms` mixin also allows customisation of the base classname:
 @include oForms('my-forms');
 ```
 
-### Additional features
+#### Additional features
 
 `o-forms` provides some additional features that can be included separately using their own mixins.
 
@@ -191,7 +200,8 @@ The `oForms` mixin also allows customisation of the base classname:
 
 For more details on specific mixins [browse the SassDoc documentation of the module](http://sassdoc.webservices.ft.com/v1/sassdoc/o-forms).
 
-## Known issues:
+
+## Troubleshooting:
 
 * Checkboxes and radio controls will not receive custom styling in IE =< 8, though they'll still receive default browser styling
 * In older versions of Firefox and depending on the version of the operating system, the select dropdowns might a default system arrow *and* a decorated arrow
@@ -199,7 +209,13 @@ For more details on specific mixins [browse the SassDoc documentation of the mod
 
 There are a number of inconsistencies in how browsers handle form events, validation and auto-fill. The Membership team has [documented the quirks](https://sites.google.com/a/ft.com/membership-subscriptions/sign-up-registration/technical-documentation/front-end-development-notes/browser-inconsistencies) it ran into during the development of the Sign Up app.
 
+
 ----
+
+## Migration Guide
+
+Upgrading from v1.x.x or v2.x.x? [Follow these instructions](#upgrade-to-v3).
+Upgrading from v0.x.x? [Follow these instructions](#upgrade-to-v1).
 
 <a name="upgrade-to-v3"></a>
 
@@ -232,6 +248,7 @@ An example of the changes should be:
 ```
 
 Any modifier classes like `o-forms--error` have remained the same.
+
 
 ----
 
@@ -266,6 +283,7 @@ Solution: products must load webfonts themselves (tipically, with [o-fonts](http
 </style>
 ```
 
+
 ### 3. Helper classes name changes
 
 The most important change is with input elements, that now have their own classes:
@@ -294,12 +312,17 @@ The most important change is with input elements, that now have their own classe
 
 If using placeholder classes or extending styles using `oFormsClass` and `oFormsPlaceholderOptionalSelector`, use normal selectors, and include the matching mixins, documented in the [SassDoc documentation of the module](http://sassdoc.webservices.ft.com/v1/sassdoc/o-forms).
 
+
+---
+
+## Contact
+
+If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-component-boilerplate/issues), visit [#ft-origami](https://financialtimes.slack.com/messages/ft-origami/) or email [Origami Support](mailto:origami-support@ft.com).
+
 ----
 
-## License
+## Licence
 
-Copyright (c) 2016 Financial Times Ltd. All rights reserved.
-
-This software is published under the [MIT licence](http://opensource.org/licenses/MIT).
+This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).
 
 [bem]: http://getbem.com/naming/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ FT-branded styles for form elements.
 - [Usage](#usage)
 	- [Markup](#markup)
 	- [Sass](#sass)
+	- [JavaScript](#javascript)
 - [Troubleshooting](#troubleshooting)
 - [Migration guide](#migration-guide)
 - [Contact](#contact)
@@ -200,6 +201,50 @@ The `oForms` mixin also allows customisation of the base classname:
 
 For more details on specific mixins [browse the SassDoc documentation of the module](http://sassdoc.webservices.ft.com/v1/sassdoc/o-forms).
 
+### JavaScript
+
+`o-forms` provides some JavaScript to help with validating form inputs. The validation works with the browsers built-in validation API to add the appropriate `o-forms` classes when a user is completing or submitting a form.
+
+By default, `o-forms` listens to the `blur` event of an input field, when a user leaves a field, the input will be validated and if an invalid input is found, the error class will be added to the input.
+
+#### Constructing
+
+An o-forms object must be constructed for every `<form>` element you have on your page that you want to validate with this module. You can do this for explicit elements like so:
+
+```js
+const OForms = require('o-forms');
+const formsEl = document.querySelector('#form-element');
+
+const forms = new OForms(formsEl);
+```
+
+Alternatively, an o.DOMContentLoaded event can be dispatched on the document to auto-construct an o-forms object for each element with a `data-o-component="o-forms"` attribute:
+
+```js
+require('o-forms');
+document.addEventListener("DOMContentLoaded", function() {
+    document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+});
+```
+
+#### Validate on form submit
+
+By default `o-forms` tests inputs on the `blur` event for each input. To defer the validation to the `submit` event of the form, you can pass an config object to set the `testEvent` when constructing `o-forms`:
+
+```js
+const OForms = require('o-forms');
+const formsEl = document.querySelector('#form-element');
+
+const forms = new OForms(formsEl, { testEvent: 'submit' });
+```
+
+Or you can set an attribute on the `<form>` element to declaratively set the test event:
+
+```html
+<form data-o-component="o-forms" data-o-forms-test-event="submit">
+	[...]
+</form>
+```
 
 ## Troubleshooting:
 

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,0 +1,10 @@
+/*global require*/
+import './../../main.js';
+
+function initDemos() {
+	document.addEventListener('DOMContentLoaded', function() {
+		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+	});
+}
+
+initDemos();

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -129,25 +129,25 @@
 	<p>This is a global message</p>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Field label</label>
+	<label class="o-forms__label" for="text-input-global-message">Field label</label>
 	<small class="o-forms__additional-info">Additional field information</small>
-	<input type="text" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" placeholder="placeholder" id="text-input-global-message" class="o-forms__text" />
 </div>
 
 <div class="o-forms__message o-forms__message--error">
 	<p>This is a global error message</p>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Field label</label>
+	<label class="o-forms__label" for="text-input-global-message-2">Field label</label>
 	<small class="o-forms__additional-info">Additional field information</small>
-	<input type="text" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" placeholder="placeholder" id="text-input-global-message-2" class="o-forms__text" />
 </div>
 
 <div class="o-forms__wrapper o-forms__wrapper--highlight">
 	<div class="o-forms">
-		<label for="o-text-default" class="o-forms__label">Label</label>
+		<label for="o-text-default-2" class="o-forms__label">Label</label>
 		<small class="o-forms__additional-info">Additional field information</small>
-		<input type="text" placeholder="placeholder" id="o-text-default" class="o-forms__text" />
+		<input type="text" placeholder="placeholder" id="o-text-default-2" class="o-forms__text" />
 	</div>
 </div>
 <div class="o-forms__wrapper o-forms__wrapper--error">
@@ -161,33 +161,33 @@
 	</div>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Text input with prefix label</label>
+	<label class="o-forms__label" for="o-text-prefixed">Text input with prefix label</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<div class="o-forms__affix-wrapper">
 		<span class="o-forms__prefix">http://</span>
-		<input type="text" placeholder="placeholder" class="o-forms__text" />
+		<input type="text" placeholder="placeholder" id="o-text-prefixed" class="o-forms__text" />
 	</div>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Text input with suffix label</label>
+	<label class="o-forms__label" for="o-text-suffixed">Text input with suffix label</label>
 	<div class="o-forms__affix-wrapper">
-		<input type="text" placeholder="placeholder" class="o-forms__text o-forms__text--suffixed" />
+		<input type="text" placeholder="placeholder" id="o-text-suffixed" class="o-forms__text o-forms__text--suffixed" />
 		<span class="o-forms__suffix">.com</span>
 	</div>
 </div>
 <div class="o-forms o-forms--error">
-	<label class="o-forms__label">Text input with prefix label (error)</label>
+	<label class="o-forms__label" for="o-text-prefixed-error">Text input with prefix label (error)</label>
 	<div class="o-forms__affix-wrapper">
 		<span class="o-forms__prefix">http://</span>
-		<input type="text" placeholder="placeholder" class="o-forms__text" />
+		<input type="text" placeholder="placeholder" id="o-text-prefixed-error" class="o-forms__text" />
 	</div>
 	<div class="o-forms__errortext">Invalid entry</div>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Select box with prefix label</label>
+	<label class="o-forms__label" for="o-select-prefixed">Select box with prefix label</label>
 	<div class="o-forms__affix-wrapper">
 		<span class="o-forms__prefix">Choose:</span>
-		<select class="o-forms__select">
+		<select class="o-forms__select" id="o-select-prefixed">
 			<option value="option1">Option 1</option>
 			<option value="option2">Option 2</option>
 			<option value="option3">Option 3</option>
@@ -197,27 +197,27 @@
 </div>
 
 <div class="o-forms">
-	<label class="o-forms__label">Text input with suffix button</label>
+	<label class="o-forms__label" for="o-text-suffix-button">Text input with suffix button</label>
 	<div class="o-forms__affix-wrapper">
-		<input type="text" placeholder="placeholder" class="o-forms__text" />
+		<input type="text" placeholder="placeholder" id="o-text-suffix-button" class="o-forms__text" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons">Go</button>
 		</div>
 	</div>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Text input with prefix button</label>
+	<label class="o-forms__label" for="o-text-prefix-button">Text input with prefix button</label>
 	<div class="o-forms__affix-wrapper">
 		<div class="o-forms__prefix">
 			<button type="button" class="o-buttons">Go</button>
 		</div>
-		<input type="text" placeholder="placeholder" class="o-forms__text" />
+		<input type="text" placeholder="placeholder" id="o-text-prefix-button" class="o-forms__text" />
 	</div>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Select box with suffix button</label>
+	<label class="o-forms__label" for="o-select-suffix-button">Select box with suffix button</label>
 	<div class="o-forms__affix-wrapper">
-		<select class="o-forms__select">
+		<select class="o-forms__select" id="o-select-suffix-button">
 			<option value="option1">Option 1</option>
 			<option value="option2">Option 2</option>
 			<option value="option3">Option 3</option>
@@ -229,19 +229,19 @@
 	</div>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Text input with prefix label and suffix button</label>
+	<label class="o-forms__label" for="o-text-prefix-suffix">Text input with prefix label and suffix button</label>
 	<div class="o-forms__affix-wrapper">
 		<span class="o-forms__prefix">http://</span>
-		<input type="text" placeholder="placeholder" class="o-forms__text" />
+		<input type="text" placeholder="placeholder" id="o-text-prefix-suffix" class="o-forms__text" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons">Go</button>
 		</div>
 	</div>
 </div>
 <div class="o-forms">
-	<label class="o-forms__label">Text input with suffix checkbox</label>
+	<label class="o-forms__label" for="o-text-suffix-checkbox">Text input with suffix checkbox</label>
 	<div class="o-forms__affix-wrapper">
-		<input type="text" placeholder="placeholder" class="o-forms__text o-forms__text--suffixed" />
+		<input type="text" placeholder="placeholder" id="o-text-suffix-checkbox" class="o-forms__text o-forms__text--suffixed" />
 		<div class="o-forms__suffix">
 			<input type="checkbox" name="checkbox" value="2" class="o-forms__checkbox" id="checkbox99" />
 			<label for="checkbox99" class="o-forms__label">Checkbox 2</label>
@@ -271,10 +271,10 @@
 </div>
 
 <div class="o-forms o-forms--wide">
-	<label class="o-forms__label">Text input with prefix label and suffix button (wide)</label>
+	<label class="o-forms__label" for="o-test-prefix-suffix-button">Text input with prefix label and suffix button (wide)</label>
 	<div class="o-forms__affix-wrapper">
 		<span class="o-forms__prefix">http://</span>
-		<input type="text" placeholder="placeholder" class="o-forms__text" />
+		<input type="text" placeholder="placeholder" id="o-test-prefix-suffix-button" class="o-forms__text" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons">Go</button>
 		</div>
@@ -285,9 +285,9 @@
 	<p>This is a global error message (wide)</p>
 </div>
 <div class="o-forms o-forms--wide">
-	<label class="o-forms__label">Field label</label>
+	<label class="o-forms__label" for="o-test-global-message-wide">Field label</label>
 	<small class="o-forms__additional-info">Additional field information</small>
-	<input type="text" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" placeholder="placeholder" id="o-test-global-message-wide" class="o-forms__text" />
 </div>
 
 <fieldset class="o-forms o-forms--wide">
@@ -303,7 +303,7 @@
 </div>
 
 <div class="o-forms o-forms--wide">
-	<label for="o-forms__textarea" class="o-forms__label">Textarea (wide)</label>
+	<label for="o-forms__textarea-wide" class="o-forms__label">Textarea (wide)</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
-	<textarea placeholder="Placeholder" id="o-forms__textarea" class="o-forms__textarea"></textarea>
+	<textarea placeholder="Placeholder" id="o-forms__textarea-wide" class="o-forms__textarea"></textarea>
 </div>

--- a/demos/src/text-inputs.mustache
+++ b/demos/src/text-inputs.mustache
@@ -1,26 +1,29 @@
-<div class="o-forms">
+<form action="">
+<div class="o-forms" data-o-component="o-forms">
 	<label for="o-forms-standard" class="o-forms__label">Text input</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
 </div>
 <div class="o-forms o-forms--valid">
 	<label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
-	<input type="text" placeholder="placeholder" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
+	<input type="text" placeholder="placeholder" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" data-o-component="o-forms" />
 </div>
-<div class="o-forms o-forms--error">
+<div class="o-forms o-forms--error" data-o-component="o-forms">
 	<label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<input type="url" placeholder="placeholder" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
 	<div class="o-forms__errortext">Please enter a valid url</div>
 </div>
-<div class="o-forms">
+<div class="o-forms" data-o-component="o-forms">
 	<label for="o-forms-disabled" class="o-forms__label">Text input disabled</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<input type="text" placeholder="placeholder" id="o-forms-disabled" class="o-forms__text o-forms__text--valid" value="Field value" disabled="disabled" />
 </div>
 
-<div class="o-forms o-forms--wide">
+<div class="o-forms o-forms--wide" data-o-component="o-forms">
 	<label for="o-forms-full" class="o-forms__label">Text input full width</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<input type="text" placeholder="placeholder" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
+<input type="submit">
+</form>

--- a/demos/src/text-inputs.mustache
+++ b/demos/src/text-inputs.mustache
@@ -1,29 +1,26 @@
-<form action="">
-<div class="o-forms" data-o-component="o-forms">
+<div class="o-forms">
 	<label for="o-forms-standard" class="o-forms__label">Text input</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
-	<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" required />
 </div>
 <div class="o-forms o-forms--valid">
 	<label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
-	<input type="text" placeholder="placeholder" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" data-o-component="o-forms" />
+	<input type="text" placeholder="placeholder" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
-<div class="o-forms o-forms--error" data-o-component="o-forms">
+<div class="o-forms o-forms--error">
 	<label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<input type="url" placeholder="placeholder" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
 	<div class="o-forms__errortext">Please enter a valid url</div>
 </div>
-<div class="o-forms" data-o-component="o-forms">
+<div class="o-forms">
 	<label for="o-forms-disabled" class="o-forms__label">Text input disabled</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<input type="text" placeholder="placeholder" id="o-forms-disabled" class="o-forms__text o-forms__text--valid" value="Field value" disabled="disabled" />
 </div>
 
-<div class="o-forms o-forms--wide" data-o-component="o-forms">
+<div class="o-forms o-forms--wide">
 	<label for="o-forms-full" class="o-forms__label">Text input full width</label>
 	<small class="o-forms__additional-info">Optional prompt text goes here</small>
 	<input type="text" placeholder="placeholder" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
-<input type="submit">
-</form>

--- a/demos/src/validation.mustache
+++ b/demos/src/validation.mustache
@@ -1,0 +1,9 @@
+<form action="" data-o-component="o-forms">
+	<div class="o-forms">
+		<label for="o-forms-standard" class="o-forms__label">Text input</label>
+		<small class="o-forms__additional-info">Optional prompt text goes here</small>
+		<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" required />
+	</div>
+
+	<input type="submit">
+</form>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,125 @@
+/*eslint-env node*/
+
+const BowerPlugin = require('bower-webpack-plugin');
+const path = require('path');
+const cwd = process.cwd();
+
+module.exports = function(config) {
+	config.set({
+
+		// base path that will be used to resolve all patterns (eg. files, exclude)
+		basePath: '',
+
+
+		// frameworks to use
+		// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+		frameworks: ['mocha', 'sinon'],
+
+		plugins: [
+			'karma-mocha',
+			'karma-phantomjs-launcher',
+			'karma-webpack',
+			'karma-sinon',
+			'karma-coverage'
+		],
+
+
+		// list of files / patterns to load in the browser
+		files: [
+			'http://cdn.polyfill.io/v2/polyfill.js?features=fetch&flags=gated',
+			'test/*.test.js'
+		],
+
+
+		// list of files to exclude
+		exclude: [
+		],
+
+
+		// preprocess matching files before serving them to the browser
+		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+		preprocessors: {
+			'test/**/*.test.js': ['webpack']
+		},
+
+
+		// test results reporter to use
+		// possible values: 'dots', 'progress', 'coverage'
+		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
+		reporters: ['progress', 'coverage'],
+
+		coverageReporter: {
+			type : 'text-summary'
+		},
+
+		// web server port
+		port: 9876,
+
+
+		// enable / disable colors in the output (reporters and logs)
+		colors: true,
+
+
+		// level of logging
+		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+		logLevel: config.LOG_INFO,
+
+
+		// enable / disable watching file and executing tests whenever any file changes
+		autoWatch: false,
+
+
+		// start these browsers
+		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+		browsers: ['PhantomJS'],
+
+
+		// Continuous Integration mode
+		// if true, Karma captures browsers, runs the tests and exits
+		singleRun: true,
+
+		webpack: {
+			quiet: true,
+			module: {
+				loaders: [
+					{
+						test: /\.js$/,
+						exclude: /node_modules/,
+						loaders: [
+							'babel?optional[]=runtime',
+							'imports?define=>false'
+						]
+					},
+					{
+						test: /\.json$/,
+						loader: 'json'
+					}
+				],
+				postLoaders: [
+					{ //delays coverage til after tests are run, fixing transpiled source coverage error
+						test: /\.js$/,
+						exclude: /(test|node_modules|bower_components)\//,
+						loader: 'istanbul-instrumenter'
+					}
+				],
+				noParse: [
+					/\/sinon\.js/,
+				]
+			},
+			resolve: {
+				root: [path.join(cwd, 'bower_components')]
+			},
+			plugins: [
+				new BowerPlugin({
+					includes:  /\.js$/
+				})
+			]
+		},
+
+		// Hide webpack output logging
+		webpackMiddleware: {
+			noInfo: true
+		}
+
+	});
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
-			'http://cdn.polyfill.io/v2/polyfill.js?features=fetch&flags=gated',
+			'https://cdn.polyfill.io/v2/polyfill.js?flags=gated&ua=safari/4',
 			'test/*.test.js'
 		],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,10 @@ module.exports = function(config) {
 		reporters: ['progress', 'coverage'],
 
 		coverageReporter: {
-			type : 'text-summary'
+			reporters: [
+				{ type : 'html' },
+				{ type : 'text-summary' }
+			]
 		},
 
 		// web server port

--- a/main.js
+++ b/main.js
@@ -1,0 +1,10 @@
+import oForms from './src/js/forms';
+
+const constructAll = function() {
+	oForms.init();
+	document.removeEventListener('o.DOMContentLoaded', constructAll);
+};
+
+document.addEventListener('o.DOMContentLoaded', constructAll);
+
+export default oForms;

--- a/origami.json
+++ b/origami.json
@@ -75,6 +75,7 @@
     ],
     "demosDefaults": {
         "sass": "demos/src/demo.scss",
+        "js": "demos/src/demo.js",
         "dependencies": [
             "o-fonts@^1.4.0"
         ]

--- a/origami.json
+++ b/origami.json
@@ -71,6 +71,12 @@
             "template": "/demos/src/pa11y.mustache",
             "hidden": true,
             "description": ""
+        },
+        {
+            "name": "js-validation",
+            "title": "Validate inputs",
+            "template": "/demos/src/validation.mustache",
+            "hidden": true
         }
     ],
     "demosDefaults": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "karma start karma.conf.js"
+  },
+  "devDependencies": {
+    "babel-loader": "^5.3.2",
+    "babel-runtime": "^5.6.15",
+    "bower-webpack-plugin": "^0.1.8",
+    "imports-loader": "^0.6.4",
+    "istanbul-instrumenter-loader": "^1.0.0",
+    "karma": "^0.13.22",
+    "karma-coverage": "^1.1.1",
+    "karma-mocha": "^0.2.2",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sinon": "^1.0.5",
+    "karma-webpack": "^1.7.0",
+    "mocha": "^3.0.2",
+    "origami-build-tools": "^5.5.0",
+    "proclaim": "^3.4.1",
+    "sinon": "^1.17.5"
+  }
+}

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -63,6 +63,21 @@ class Forms {
 		event.target.submit();
 	}
 
+	validateInput(input) {
+		if (input.checkValidity() === false) {
+			this.invalidInput(input);
+			return false;
+		}
+
+		const oFormsEl = input.closest('.o-forms');
+
+		if ((oFormsEl instanceof HTMLElement) && oFormsEl.classList.contains('o-forms--error')) {
+			oFormsEl.classList.remove('o-forms--error');
+		}
+
+		return true;
+	}
+
 	invalidInput(input) {
 		input.closest('.o-forms').classList.add('o-forms--error');
 	}
@@ -79,24 +94,15 @@ class Forms {
 		this.validateInput(input);
 	}
 
-	validateInput(input) {
-		if (input.checkValidity() === false) {
-			this.invalidInput(input);
-			return false;
-		}
-
-		return true;
-	}
-
 	findInputs() {
-		return Array.from(this.FormEl.querySelectorAll('input, select, textarea, button, form'));
+		return Array.from(this.FormEl.querySelectorAll('input, select, textarea, button'));
 	}
 
 	destroy() {
 		this.FormEl.removeEventListener('submit', this.validateForm.bind(this));
 		this.findInputs(this.FormEl).map(input => {
-			input.removeEventListener('invalid', this.invalidInput);
-			input.removeEventListener('blur', this.validateInput.bind(this));
+			input.removeEventListener('invalid', this.handleInvalidEvent.bind(this));
+			input.removeEventListener('blur', this.handleBlurEvent.bind(this));
 		});
 
 		this.opts = undefined;

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -1,0 +1,22 @@
+class Forms {
+
+	constructor (FormEl, opts) {
+		this.FormEl = FormEl;
+		this.opts = opts || {values: "default"};
+	}
+
+	static init (rootEl, opts) {
+		if (!rootEl) {
+			rootEl = document.body;
+		}
+		if (!(rootEl instanceof HTMLElement)) {
+			rootEl = document.querySelector(rootEl);
+		}
+		if (rootEl instanceof HTMLElement && /\bo-forms\b/.test(rootEl.getAttribute('data-o-component'))) {
+			return new Forms(rootEl, opts);
+		}
+		return [].map.call(rootEl.querySelectorAll('[data-o-component="o-forms"]'), rootEl => new Forms(rootEl, opts));
+	}
+}
+
+export default Forms;

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -2,7 +2,65 @@ class Forms {
 
 	constructor (FormEl, opts) {
 		this.FormEl = FormEl;
-		this.opts = opts || {values: "default"};
+		this.opts = opts || { testEvent: "blur" };
+		this.validFormEls = [
+			HTMLFormElement,
+			HTMLInputElement,
+			HTMLSelectElement,
+			HTMLButtonElement,
+			HTMLTextAreaElement
+		];
+
+		console.log('hello forms!');
+
+		// Find the closest <form> element unless
+		// the constructed element is a <form> element already
+		this.ParentForm = (this.FormEl instanceof HTMLFormElement) ? this.FormEl : this.FormEl.closest('form');
+
+		// Add the event listeners
+		this.listeners();
+	}
+
+	// element.closest(form) - to find the form element
+	// Events: blur or submit
+
+	listeners() {
+		if (this.opts.testEvent === 'submit') {
+			this.ParentForm.addEventListener('submit', this.checkAllInputs, false);
+			return;
+		}
+
+		// If the constructed element is a form element add
+		// a listener on blur. Otherwise find any child inputs
+		if (this.isValidFormElement()) {
+			this.FormEl.addEventListener('blur', this.checkSingleInput, false);
+		} else {
+			this.findInputs().map((input) => {
+				input.addEventListener('blur', this.checkSingleInput, false);
+			});
+		}
+	}
+
+	checkAllInputs(event) {
+		event.preventDefault();
+
+		console.log('hello');
+	}
+
+	checkSingleInput(event) {
+		console.log('hello single');
+	}
+
+	checkInputValidity(input) {
+		console.log("input validity", input);
+	}
+
+	isValidFormElement() {
+		return this.validFormEls.some((element) => this.FormEl instanceof element);
+	}
+
+	findInputs() {
+		return Array.from(this.FormEl.querySelectorAll('input, select, textarea, button, form'));
 	}
 
 	static init (rootEl, opts) {

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -120,7 +120,8 @@ class Forms {
 		if (rootEl instanceof HTMLElement && /\bo-forms\b/.test(rootEl.getAttribute('data-o-component'))) {
 			return new Forms(rootEl, opts);
 		}
-		return [].map.call(rootEl.querySelectorAll('[data-o-component="o-forms"]'), rootEl => new Forms(rootEl, opts));
+
+		return Array.from(rootEl.querySelectorAll('[data-o-component="o-forms"]'), rootEl => new Forms(rootEl, opts));
 	}
 }
 

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -39,13 +39,13 @@ class Forms {
 			// All other browsers will report each item invalid on
 			// submit and prevent a form submission.
 			this.findInputs(this.FormEl).map(input => {
-				input.addEventListener('invalid', this.invalidInput, false);
+				input.addEventListener('invalid', this.handleInvalidEvent.bind(this), false);
 			});
 
 			return;
 		} else {
 			this.findInputs().map((input) => {
-				input.addEventListener('blur', this.validateInput.bind(this), false);
+				input.addEventListener('blur', this.handleBlurEvent.bind(this), false);
 			});
 		}
 	}
@@ -55,7 +55,7 @@ class Forms {
 
 		const checkedInputs = this.findInputs(this.FormEl).map(input => this.validateInput(input));
 
-		if (checkedInputs.includes(false)) {
+		if (checkedInputs.some((val) => val === false)) {
 			return;
 		}
 
@@ -63,16 +63,25 @@ class Forms {
 		event.target.submit();
 	}
 
-	invalidInput(event) {
-		const input = event.target;
+	invalidInput(input) {
 		input.closest('.o-forms').classList.add('o-forms--error');
 	}
 
-	validateInput(event) {
+	handleInvalidEvent(event) {
 		const input = event.target;
 
+		this.invalidInput(input);
+	}
+
+	handleBlurEvent(event) {
+		const input = event.target;
+
+		this.validateInput(input);
+	}
+
+	validateInput(input) {
 		if (input.checkValidity() === false) {
-			this.invalidInput(event);
+			this.invalidInput(input);
 			return false;
 		}
 

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -2,7 +2,6 @@ class Forms {
 
 	constructor (FormEl, opts) {
 		this.FormEl = FormEl;
-		this.opts = opts || { testEvent: "blur" };
 		this.validFormEls = [
 			HTMLFormElement,
 			HTMLInputElement,
@@ -10,6 +9,14 @@ class Forms {
 			HTMLButtonElement,
 			HTMLTextAreaElement
 		];
+
+		const declaredTestEvent = this.FormEl.getAttribute('data-o-forms-test-event');
+
+		if (declaredTestEvent) {
+			opts = { testEvent: declaredTestEvent };
+		}
+
+		this.opts = opts || { testEvent: "blur" };
 
 		// o-forms should only be registered against a <form>
 		// element. If not, return to prevent errors

--- a/src/scss/message.scss
+++ b/src/scss/message.scss
@@ -15,11 +15,13 @@
 		font-size: 18px;
 		background-color: oColorsGetColorFor(o-forms__wrapper-highlight, background);
 
+		// sass-lint:disable mixins-before-declarations
 		@include _oFormsBreakpoint {
 			border-radius: $_o-forms-field-border-radius;
 			margin-right: 0;
 			margin-left: 0;
 		}
+		// sass-lint:enable no-vendor-prefixes
 
 		p {
 			padding: 8px 0;

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -6,8 +6,6 @@
 /// Common field styles
 @mixin oFormsCommonFieldBase {
 	box-sizing: border-box;
-	-moz-appearance: none;
-	-webkit-appearance: none;
 	width: 100%;
 	max-width: $_o-forms-field-max-width;
 	height: $_o-forms-field-default-height;
@@ -23,9 +21,15 @@
 	outline: none;
 	transition: 0.15s box-shadow ease-in;
 
+	// sass-lint:disable no-vendor-prefixes
+	-moz-appearance: none;
+	-webkit-appearance: none;
+	// sass-lint:enable no-vendor-prefixes
+
 	&:focus {
 		@include oFormsCommonFieldFocus;
 	}
+
 	&:disabled {
 		@include oFormsCommonFieldDisabled;
 	}
@@ -67,10 +71,12 @@
 	padding: 0;
 	border: 0;
 
+	// sass-lint:disable mixins-before-declarations
 	@include _oFormsBreakpoint {
 		padding-right: $_o-forms-padding;
 		padding-left: $_o-forms-padding;
 	}
+	// sass-lint:enable mixins-before-declarations
 
 	&--wide {
 		@include oFormsFullWidth;
@@ -80,7 +86,9 @@
 /// All the field to extend to the full width
 /// of the container
 @mixin oFormsFullWidth() {
+	// sass-lint:disable no-important
 	max-width: none !important;
+	// sass-lint:enable no-important
 }
 
 /// Target styles at Internet Explorer 8 only

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -33,11 +33,11 @@
 		font-size: 14px;
 		font-weight: 400;
 		line-height: $_o-forms__radiocheckbox-default-size + 1px;
-		// scss-lint:disable VendorPrefixes VendorPrefix
+		// sass-lint:disable no-vendor-prefixes
 		-moz-user-select: none;
 		-webkit-user-select: none;
 		-ms-user-select: none;
-		// scss-lint:enable VendorPrefixes VendorPrefix
+		// sass-lint:enable no-vendor-prefixes
 
 		// When in a prefix/suffix, clear the margins
 		// and reduce the font size
@@ -88,8 +88,13 @@
 		transition: 0.1s opacity ease-in;
 	}
 
-	#{$radio}--align-right + #{$label}::after,
-	#{$checkbox}--align-right + #{$label}::after {
+	// AO: Hack to make sass-lint pass, it doesn't like
+	// interpolation of selectors like #{$radio}--align-right
+	// and throws a Fatal error, this however, works!
+	$align-right: '--align-right';
+
+	#{$radio}#{$align-right} + #{$label}::after,
+	#{$checkbox}#{$align-right} + #{$label}::after {
 		right: 0;
 		left: auto;
 	}
@@ -133,6 +138,7 @@
 			top: 2px;
 			vertical-align: top;
 		}
+
 		#{$checkbox} + #{$label},
 		#{$radio} + #{$label} {
 			padding-left: 0;

--- a/src/scss/mixins/_select.scss
+++ b/src/scss/mixins/_select.scss
@@ -7,10 +7,10 @@
 	color: oColorsGetPaletteColor('grey-tint5');
 	background-image: url(str-replace("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrows-up-down?source=o-icons&tint=%23#{$icon-color}&format=svg", "#", ""));
 	// For iOS 6 that doesn't support 4-value background-position
-	// scss-lint:disable DuplicateProperty
+	// sass-lint:disable no-duplicate-properties
 	background-position: right center;
 	background-position: $_o-forms-field-default-padding-leftright $_o-forms-field-default-padding-leftright center;
-	// scss-lint:enable DuplicateProperty
+	// sass-lint:enable no-duplicate-properties
 	background-repeat: no-repeat;
 	background-origin: border-box;
 	background-size: $_o-forms__select-iconsize;
@@ -27,20 +27,22 @@
 	// In old IE, since we can't hide the stock browser arrow, we'll just keep it:
 	// 1. Remove additional padding
 	// 2. Remove the custom arrow
-	// scss-lint:disable DuplicateProperty
+	// sass-lint:disable no-duplicate-properties
 	padding-right: #{$_o-forms-field-default-padding-leftright}\9; // [1]
 	background-image: none\9; // [2]
-	// scss-lint:enable DuplicateProperty
+	// sass-lint:enable no-duplicate-properties
 
 	// Hide stock browser select arrow in Firefox
 	text-indent: 0.01px;
 	text-overflow: '';
 
 	// Hide stock browser arrow in IE 10+
+	// sass-lint:disable no-vendor-prefixes
 	&::-ms-expand {
 		display: none;
 		color: oColorsGetPaletteColor('white');
 	}
+	// sass-lint:enable no-vendor-prefixes
 }
 
 @mixin oFormsSelectMulti() {

--- a/src/scss/prefix-suffix.scss
+++ b/src/scss/prefix-suffix.scss
@@ -33,7 +33,8 @@
 		padding: $_o-forms-field-default-padding-top $_o-forms-field-default-padding-leftright $_o-forms-field-default-padding-bottom;
 		cursor: pointer;
 		font: inherit;
-		// scss-lint:disable VendorPrefixes VendorPrefix
+
+		// sass-lint:disable no-vendor-prefixes
 		-moz-appearance: none;
 		-webkit-appearance: none;
 		-moz-user-select: none;
@@ -44,6 +45,7 @@
 			border: 0;
 			padding: 0;
 		}
+		// sass-lint:enable no-vendor-prefixes
 	}
 
 	.#{$class}__prefix button {
@@ -75,10 +77,11 @@
 		text-align: center;
 		background-color: oColorsGetColorFor(o-forms__prefixsuffix, background);
 		color: oColorsGetColorFor(o-forms--prefixsuffix o-forms-field-standard, text);
-		// scss-lint:disable VendorPrefixes VendorPrefix
+		// sass-lint:disable no-vendor-prefixes
 		-moz-user-select: none;
 		-webkit-user-select: none;
 		-ms-user-select: none;
+		// sass-lint:enable no-vendor-prefixes
 	}
 
 	.#{$class}__prefix {

--- a/src/scss/unskin.scss
+++ b/src/scss/unskin.scss
@@ -1,7 +1,7 @@
 /// Unskin a field entirely, but keep its structure intact
 @mixin oFormsUnskin($class: 'o-forms') {
 	.#{$class}--unskin {
-		// scss-lint:disable ImportantRule
+		// sass-lint:disable no-vendor-prefixes no-important
 		-moz-appearance: none !important;
 		-webkit-appearance: none !important;
 		border: 0 !important;
@@ -14,6 +14,7 @@
 		-webkit-text-fill-color: oColorsGetPaletteColor('grey-tint5') !important;
 		opacity: 1 !important;
 		border-radius: 0 !important;
+		// sass-lint:disable no-vendor-prefixes no-important
 	}
 }
 

--- a/src/scss/wrapper.scss
+++ b/src/scss/wrapper.scss
@@ -7,15 +7,6 @@
 		margin-left: $_o-forms-padding * -1;
 		padding-right: $_o-forms-padding;
 		padding-left: $_o-forms-padding;
-
-		@include _oFormsBreakpoint {
-			border-radius: $_o-forms-field-border-radius;
-			margin-right: 0;
-			margin-left: 0;
-			padding-left: 0;
-			padding-right: 0;
-		}
-
 		// Clearfix
 		zoom: 1;
 
@@ -26,6 +17,14 @@
 		}
 		&:after {
 			clear: both;
+		}
+
+		@include _oFormsBreakpoint {
+			border-radius: $_o-forms-field-border-radius;
+			margin-right: 0;
+			margin-left: 0;
+			padding-left: 0;
+			padding-right: 0;
 		}
 
 		&--highlight {

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -6,6 +6,30 @@ import * as fixtures from './helpers/fixtures';
 const Forms = require('./../main');
 
 describe("Forms", () => {
-	it('xxxx', () => {
+	// beforeEach(() => {
+	// });
+
+	// afterEach(() => {
+	// });
+
+	it('sets default testEvent to blur', () => {
+		fixtures.htmlCode();
+
+		const formEl = document.querySelector('[data-o-component="o-forms"]');
+		const testForms = new Forms(formEl);
+
+		proclaim.equal(testForms.opts.testEvent, 'blur');
+	});
+
+	it('destroys itself when not initialised on a <form> element', () => {
+		const html = `<form><input type="text" data-o-component="o-forms" /></form>`;
+		fixtures.insert(html);
+
+		const formEl = document.querySelector('[data-o-component="o-forms"]');
+		const testForms = new Forms(formEl);
+
+		proclaim.isUndefined(testForms.FormEl);
+		proclaim.isUndefined(testForms.opts);
+		proclaim.isUndefined(testForms.validFormEls);
 	});
 });

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -8,11 +8,18 @@ const Forms = require('./../main');
 
 describe("Forms", () => {
 	describe("configuration", () => {
+		let testForms;
+
+		afterEach(() => {
+			fixtures.reset();
+			testForms.destroy();
+		});
+
 		it('sets default testEvent to blur', () => {
 			fixtures.htmlCode();
 
 			const formEl = document.querySelector('[data-o-component="o-forms"]');
-			const testForms = new Forms(formEl);
+			testForms = new Forms(formEl);
 
 			proclaim.equal(testForms.opts.testEvent, 'blur');
 		});
@@ -25,7 +32,7 @@ describe("Forms", () => {
 			const input = formEl.querySelector('input');
 			const inputSpy = sinon.spy(input, 'addEventListener');
 
-			const testForms = new Forms(formEl);
+			testForms = new Forms(formEl);
 
 			proclaim.isTrue(inputSpy.calledOnce);
 		});
@@ -35,7 +42,7 @@ describe("Forms", () => {
 
 			const formEl = document.querySelector('[data-o-component="o-forms"]');
 			const opts = { testEvent: 'submit' };
-			const testForms = new Forms(formEl, opts);
+			testForms = new Forms(formEl, opts);
 
 			proclaim.equal(testForms.opts.testEvent, 'submit');
 		});
@@ -45,7 +52,7 @@ describe("Forms", () => {
 			fixtures.insert(html);
 
 			const formEl = document.querySelector('[data-o-component="o-forms"]');
-			const testForms = new Forms(formEl);
+			testForms = new Forms(formEl);
 
 			proclaim.equal(testForms.opts.testEvent, 'submit');
 		});
@@ -59,7 +66,7 @@ describe("Forms", () => {
 			const input = formEl.querySelector('input');
 			const inputSpy = sinon.spy(input, 'addEventListener');
 
-			const testForms = new Forms(formEl);
+			testForms = new Forms(formEl);
 
 			proclaim.isTrue(inputSpy.calledOnce);
 			proclaim.isTrue(formSpy.calledOnce);
@@ -68,9 +75,9 @@ describe("Forms", () => {
 
 	describe("handles inputs", () => {
 		let formEl;
-		let testForms;
 		let input;
 		let oFormsEl;
+		let testForms;
 
 		beforeEach(() => {
 			fixtures.htmlCode();
@@ -86,7 +93,7 @@ describe("Forms", () => {
 
 			oFormsEl = undefined;
 			input = undefined;
-			testForms = undefined;
+			testForms.destroy();
 
 			fixtures.reset();
 		});

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -21,15 +21,38 @@ describe("Forms", () => {
 		proclaim.equal(testForms.opts.testEvent, 'blur');
 	});
 
-	it('destroys itself when not initialised on a <form> element', () => {
-		const html = `<form><input type="text" data-o-component="o-forms" /></form>`;
+	it('sets testEvent to correct options when constructed with options', () => {
+		fixtures.htmlCode();
+
+		const formEl = document.querySelector('[data-o-component="o-forms"]');
+		const opts = { testEvent: 'submit' };
+		const testForms = new Forms(formEl, opts);
+
+		proclaim.equal(testForms.opts.testEvent, 'submit');
+	});
+
+	it('sets testEvent to correct options when constructed from data attr', () => {
+		const html = `<form data-o-component="o-forms" data-o-forms-test-event="submit"><input type="text" /></form>`;
 		fixtures.insert(html);
 
 		const formEl = document.querySelector('[data-o-component="o-forms"]');
 		const testForms = new Forms(formEl);
 
-		proclaim.isUndefined(testForms.FormEl);
-		proclaim.isUndefined(testForms.opts);
-		proclaim.isUndefined(testForms.validFormEls);
+		proclaim.equal(testForms.opts.testEvent, 'submit');
+	});
+
+	describe("destroy method", () => {
+		it('destroys itself when not initialised on a <form> element', () => {
+			const html = `<form><input type="text" data-o-component="o-forms" /></form>`;
+			fixtures.insert(html);
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl);
+
+			proclaim.isUndefined(testForms.FormEl);
+			proclaim.isUndefined(testForms.opts);
+			proclaim.isUndefined(testForms.validFormEls);
+		});
+
 	});
 });

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha, sinon, proclaim */
+
 import proclaim from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
 import * as fixtures from './helpers/fixtures';
@@ -21,7 +22,7 @@ describe("Forms", () => {
 		proclaim.equal(testForms.opts.testEvent, 'blur');
 	});
 
-	it('sets testEvent to correct options when constructed with options', () => {
+	it('sets testEvent to correct options when constructed manually', () => {
 		fixtures.htmlCode();
 
 		const formEl = document.querySelector('[data-o-component="o-forms"]');
@@ -39,6 +40,49 @@ describe("Forms", () => {
 		const testForms = new Forms(formEl);
 
 		proclaim.equal(testForms.opts.testEvent, 'submit');
+	});
+
+	describe("handles invalid element", () => {
+		it('adds the error class to the form when an input is invalid on blur', () => {
+			fixtures.htmlCode();
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl);
+
+			const input = document.querySelector('#required-input');
+			const oFormsEl = input.closest('.o-forms');
+
+			proclaim.isFalse(oFormsEl.classList.contains('o-forms--error'));
+
+			input.focus();
+			input.value = '';
+			input.blur();
+
+			proclaim.isTrue(oFormsEl.classList.contains('o-forms--error'));
+		});
+
+		it('adds the error class to the form when an input is invalid on submit', (done) => {
+			fixtures.htmlCode();
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl, {testEvent: 'submit'});
+
+			const input = document.querySelector('#required-input');
+			const oFormsEl = input.closest('.o-forms');
+
+			const submitButton = document.querySelector('input[type="submit"]');
+
+			proclaim.isFalse(oFormsEl.classList.contains('o-forms--error'));
+
+			formEl.addEventListener('submit', (event) => {
+				event.preventDefault();
+
+				proclaim.isTrue(oFormsEl.classList.contains('o-forms--error'));
+				done();
+			}, false);
+
+			submitButton.click();
+		});
 	});
 
 	describe("destroy method", () => {

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -165,5 +165,39 @@ describe("Forms", () => {
 			proclaim.isUndefined(testForms.validFormEls);
 		});
 
+		it("removes the event listeners from the FormEl on submit", () => {
+			fixtures.htmlCode();
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl);
+
+			let elSpy = sinon.spy(formEl, 'removeEventListener');
+			testForms.destroy();
+
+			proclaim.isTrue(elSpy.calledOnce);
+		});
+
+		it("removes the event listeners from the FormEl inputs", (done) => {
+			fixtures.htmlCode();
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl);
+
+			const spys = [];
+			const inputs = Array.from(formEl.querySelectorAll('input, select, textarea, button'));
+
+			inputs.map((input) => {
+				spys.push(sinon.spy(input, 'removeEventListener'));
+			});
+
+			testForms.destroy();
+
+			spys.map((spy) => {
+				proclaim.isTrue(spy.calledTwice);
+			});
+
+			done();
+		});
+
 	});
 });

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -1,0 +1,11 @@
+/* eslint-env mocha, sinon, proclaim */
+import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+import * as fixtures from './helpers/fixtures';
+
+const Forms = require('./../main');
+
+describe("Forms", () => {
+	it('xxxx', () => {
+	});
+});

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -88,7 +88,6 @@ describe("Forms", () => {
 		});
 
 		afterEach(() => {
-			formEl.removeEventListener('submit');
 			formEl = undefined;
 
 			oFormsEl = undefined;

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -17,6 +17,19 @@ describe("Forms", () => {
 			proclaim.equal(testForms.opts.testEvent, 'blur');
 		});
 
+		it('adds correct event listeners to form and inputs for blur config', () => {
+			const html = `<form data-o-component="o-forms"><input type="text" /></form>`;
+			fixtures.insert(html);
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const input = formEl.querySelector('input');
+			const inputSpy = sinon.spy(input, 'addEventListener');
+
+			const testForms = new Forms(formEl);
+
+			proclaim.isTrue(inputSpy.calledOnce);
+		});
+
 		it('sets testEvent to correct options when constructed manually', () => {
 			fixtures.htmlCode();
 
@@ -35,6 +48,21 @@ describe("Forms", () => {
 			const testForms = new Forms(formEl);
 
 			proclaim.equal(testForms.opts.testEvent, 'submit');
+		});
+
+		it('adds correct event listeners to form and inputs for submit config', () => {
+			const html = `<form data-o-component="o-forms" data-o-forms-test-event="submit"><input type="text" /></form>`;
+			fixtures.insert(html);
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const formSpy = sinon.spy(formEl, 'addEventListener');
+			const input = formEl.querySelector('input');
+			const inputSpy = sinon.spy(input, 'addEventListener');
+
+			const testForms = new Forms(formEl);
+
+			proclaim.isTrue(inputSpy.calledOnce);
+			proclaim.isTrue(formSpy.calledOnce);
 		});
 	});
 

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -7,12 +7,6 @@ import * as fixtures from './helpers/fixtures';
 const Forms = require('./../main');
 
 describe("Forms", () => {
-	// beforeEach(() => {
-	// });
-
-	// afterEach(() => {
-	// });
-
 	describe("configuration", () => {
 		it('sets default testEvent to blur', () => {
 			fixtures.htmlCode();
@@ -59,14 +53,14 @@ describe("Forms", () => {
 		});
 
 		afterEach(() => {
-			fixtures.reset();
-
 			formEl.removeEventListener('submit');
 			formEl = undefined;
 
+			oFormsEl = undefined;
 			input = undefined;
-			oFormsEl = input.closest('.o-forms');
 			testForms = undefined;
+
+			fixtures.reset();
 		});
 
 		it('adds the error class to the form when an input is invalid on blur', () => {
@@ -138,6 +132,23 @@ describe("Forms", () => {
 			const inputEls = testForms.findInputs();
 
 			proclaim.lengthEquals(inputEls, 7);
+		});
+
+		it('adds a class to the ancestor o-forms element', () => {
+			const html = `<div class="o-forms"><input type="text" /></div>`;
+			fixtures.insert(html);
+
+			const formEl = document.createElement('div');
+			formEl.setAttribute('data-o-component', 'o-forms');
+
+			const testForms = new Forms(formEl);
+			const input = document.querySelector('input');
+			const oFormsEl = input.closest('.o-forms');
+
+			proclaim.isFalse(oFormsEl.classList.contains('o-forms--error'));
+
+			testForms.invalidInput(input);
+			proclaim.isTrue(oFormsEl.classList.contains('o-forms--error'));
 		});
 	});
 

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -13,44 +13,64 @@ describe("Forms", () => {
 	// afterEach(() => {
 	// });
 
-	it('sets default testEvent to blur', () => {
-		fixtures.htmlCode();
-
-		const formEl = document.querySelector('[data-o-component="o-forms"]');
-		const testForms = new Forms(formEl);
-
-		proclaim.equal(testForms.opts.testEvent, 'blur');
-	});
-
-	it('sets testEvent to correct options when constructed manually', () => {
-		fixtures.htmlCode();
-
-		const formEl = document.querySelector('[data-o-component="o-forms"]');
-		const opts = { testEvent: 'submit' };
-		const testForms = new Forms(formEl, opts);
-
-		proclaim.equal(testForms.opts.testEvent, 'submit');
-	});
-
-	it('sets testEvent to correct options when constructed from data attr', () => {
-		const html = `<form data-o-component="o-forms" data-o-forms-test-event="submit"><input type="text" /></form>`;
-		fixtures.insert(html);
-
-		const formEl = document.querySelector('[data-o-component="o-forms"]');
-		const testForms = new Forms(formEl);
-
-		proclaim.equal(testForms.opts.testEvent, 'submit');
-	});
-
-	describe("handles invalid element", () => {
-		it('adds the error class to the form when an input is invalid on blur', () => {
+	describe("configuration", () => {
+		it('sets default testEvent to blur', () => {
 			fixtures.htmlCode();
 
 			const formEl = document.querySelector('[data-o-component="o-forms"]');
 			const testForms = new Forms(formEl);
 
-			const input = document.querySelector('#required-input');
-			const oFormsEl = input.closest('.o-forms');
+			proclaim.equal(testForms.opts.testEvent, 'blur');
+		});
+
+		it('sets testEvent to correct options when constructed manually', () => {
+			fixtures.htmlCode();
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const opts = { testEvent: 'submit' };
+			const testForms = new Forms(formEl, opts);
+
+			proclaim.equal(testForms.opts.testEvent, 'submit');
+		});
+
+		it('sets testEvent to correct options when constructed from data attr', () => {
+			const html = `<form data-o-component="o-forms" data-o-forms-test-event="submit"><input type="text" /></form>`;
+			fixtures.insert(html);
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl);
+
+			proclaim.equal(testForms.opts.testEvent, 'submit');
+		});
+	});
+
+	describe("handles inputs", () => {
+		let formEl;
+		let testForms;
+		let input;
+		let oFormsEl;
+
+		beforeEach(() => {
+			fixtures.htmlCode();
+			formEl = document.querySelector('[data-o-component="o-forms"]');
+
+			input = document.querySelector('#required-input');
+			oFormsEl = input.closest('.o-forms');
+		});
+
+		afterEach(() => {
+			fixtures.reset();
+
+			formEl.removeEventListener('submit');
+			formEl = undefined;
+
+			input = undefined;
+			oFormsEl = input.closest('.o-forms');
+			testForms = undefined;
+		});
+
+		it('adds the error class to the form when an input is invalid on blur', () => {
+			testForms = new Forms(formEl);
 
 			proclaim.isFalse(oFormsEl.classList.contains('o-forms--error'));
 
@@ -62,15 +82,8 @@ describe("Forms", () => {
 		});
 
 		it('adds the error class to the form when an input is invalid on submit', (done) => {
-			fixtures.htmlCode();
-
-			const formEl = document.querySelector('[data-o-component="o-forms"]');
-			const testForms = new Forms(formEl, {testEvent: 'submit'});
-
-			const input = document.querySelector('#required-input');
-			const oFormsEl = input.closest('.o-forms');
-
 			const submitButton = document.querySelector('input[type="submit"]');
+			testForms = new Forms(formEl, { testEvent: 'submit' });
 
 			proclaim.isFalse(oFormsEl.classList.contains('o-forms--error'));
 
@@ -82,6 +95,49 @@ describe("Forms", () => {
 			}, false);
 
 			submitButton.click();
+		});
+
+		describe("handles valid inputs", () => {
+			beforeEach(() => {
+				testForms = new Forms(formEl);
+			});
+
+			it('submits form when inputs are valid', (done) => {
+				const submitButton = document.querySelector('input[type="submit"]');
+
+				oFormsEl.value = 'some input';
+
+				formEl.addEventListener('submit', (event) => {
+					event.preventDefault();
+
+					done();
+				}, false);
+
+				submitButton.click();
+			});
+
+			it('removes error class when input is valid', () => {
+				oFormsEl.classList.add('o-forms--error');
+
+				input.focus();
+				input.value = 'some input';
+				input.blur();
+
+				proclaim.isFalse(oFormsEl.classList.contains('o-forms--error'));
+			});
+		});
+	});
+
+	describe("methods", () => {
+		it('selects all form control elements in a form', () => {
+			fixtures.allInputsHtmlCode();
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl);
+
+			const inputEls = testForms.findInputs();
+
+			proclaim.lengthEquals(inputEls, 7);
 		});
 	});
 

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -162,6 +162,22 @@ describe("Forms", () => {
 			proclaim.lengthEquals(inputEls, 7);
 		});
 
+		it('validate forms method', () => {
+			const html = `<div data-o-component="o-forms" class="o-forms o-forms--error"><input type="text" /></div>`;
+			fixtures.insert(html);
+
+			const formEl = document.querySelector('[data-o-component="o-forms"]');
+			const testForms = new Forms(formEl);
+
+			const input = document.querySelector('input');
+
+			const validateResult = testForms.validateInput(input);
+
+			proclaim.isTrue(validateResult);
+
+			proclaim.isFalse(formEl.classList.contains('o-forms--error'));
+		});
+
 		it('adds a class to the ancestor o-forms element', () => {
 			const html = `<div class="o-forms"><input type="text" /></div>`;
 			fixtures.insert(html);

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -21,17 +21,18 @@ function insert(html) {
 
 function htmlCode () {
 	const html = `<div>
-		<h1>Basic Demo</h1>
 		<form data-o-component="o-forms" id="element">
 			<div class="o-forms">
 				<label for="o-forms-standard" class="o-forms__label">Text input</label>
-				<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
+				<input type="text" id="required-input" placeholder="placeholder" class="o-forms__text" required />
 			</div>
 
 			<div class="o-forms">
 				<label for="o-forms-standard" class="o-forms__label">Text input</label>
-				<input type="email" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
+				<input type="email" id="standard-input" placeholder="placeholder" class="o-forms__text" />
 			</div>
+
+			<input type="submit">
 		</form>
 	</div>
 	`;

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -39,8 +39,28 @@ function htmlCode () {
 	insert(html);
 }
 
+function allInputsHtmlCode () {
+	const html = `<div>
+		<form data-o-component="o-forms" id="element">
+			<input type="text" id="required-input" placeholder="placeholder" class="o-forms__text" required />
+			<input type="email" id="standard-input" placeholder="placeholder" class="o-forms__text" />
+			<select class="o-forms__select">
+				<option>test</option>
+			</select>
+			<input type="checkbox">
+			<textarea></textarea>
+			<button>Reset</button>
+
+			<input type="submit">
+		</form>
+	</div>
+	`;
+	insert(html);
+}
+
 export {
 	insert,
 	htmlCode,
+	allInputsHtmlCode,
 	reset
  };

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -23,7 +23,17 @@ function insert(html) {
 function htmlCode () {
 	const html = `<div>
 		<h1>Basic Demo</h1>
-		<div class="o-forms" data-o-component="o-forms" id="element"></div>
+		<form>
+			<div class="o-forms" data-o-component="o-forms" id="element">
+				<label for="o-forms-standard" class="o-forms__label">Text input</label>
+				<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
+			</div>
+
+			<div class="o-forms" data-o-component="o-forms">
+				<label for="o-forms-standard" class="o-forms__label">Text input</label>
+				<input type="email" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
+			</div>
+		</form>
 	</div>
 	`;
 	insert(html);

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -19,7 +19,6 @@ function insert(html) {
 	sandboxEl.innerHTML = html;
 }
 
-
 function htmlCode () {
 	const html = `<div>
 		<h1>Basic Demo</h1>

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,0 +1,35 @@
+let sandboxEl;
+
+function createSandbox() {
+	if (document.querySelector('.sandbox')) {
+		sandboxEl = document.querySelector('.sandbox');
+	} else {
+		sandboxEl = document.createElement('div');
+		sandboxEl.setAttribute('class', 'sandbox');
+		document.body.appendChild(sandboxEl);
+	}
+}
+
+function reset() {
+	sandboxEl.innerHTML = '';
+}
+
+function insert(html) {
+	createSandbox();
+	sandboxEl.innerHTML = html;
+}
+
+
+function htmlCode () {
+	const html = `<div>
+		<h1>Basic Demo</h1>
+		<div class="o-forms" data-o-component="o-forms" id="element"></div>
+	</div>
+	`;
+	insert(html);
+}
+
+export {
+	htmlCode,
+	reset
+ };

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -23,13 +23,13 @@ function insert(html) {
 function htmlCode () {
 	const html = `<div>
 		<h1>Basic Demo</h1>
-		<form>
-			<div class="o-forms" data-o-component="o-forms" id="element">
+		<form data-o-component="o-forms" id="element">
+			<div class="o-forms">
 				<label for="o-forms-standard" class="o-forms__label">Text input</label>
 				<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
 			</div>
 
-			<div class="o-forms" data-o-component="o-forms">
+			<div class="o-forms">
 				<label for="o-forms-standard" class="o-forms__label">Text input</label>
 				<input type="email" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" />
 			</div>
@@ -40,6 +40,7 @@ function htmlCode () {
 }
 
 export {
+	insert,
 	htmlCode,
 	reset
  };

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,0 +1,52 @@
+/* eslint-env mocha, sinon, proclaim */
+import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+import * as fixtures from './helpers/fixtures';
+
+const Forms = require('./../main');
+
+describe("Forms", () => {
+	it('is defined', () => {
+		proclaim.equal(typeof Forms, 'function');
+	});
+
+	it('has a static init method', () => {
+		proclaim.equal(typeof Forms.init, 'function');
+	});
+
+	it("should autoinitialize", (done) => {
+		const initSpy = sinon.spy(Forms, 'init');
+		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+		setTimeout(function(){
+			proclaim.equal(initSpy.called, true);
+			initSpy.restore();
+			done();
+		}, 100);
+	});
+
+	it("should not autoinitialize when the event is not dispached", () => {
+		const initSpy = sinon.spy(Forms, 'init');
+		proclaim.equal(initSpy.called, false);
+	});
+
+	describe("should create a new", () => {
+		beforeEach(() => {
+				fixtures.htmlCode();
+		});
+
+		afterEach(() => {
+			fixtures.reset();
+		});
+
+		it("component array when initialized", () => {
+			const boilerplate = Forms.init();
+			proclaim.equal(boilerplate instanceof Array, true);
+			proclaim.equal(boilerplate[0] instanceof Forms, true);
+		});
+
+		it("single component when initialized with a root element", () => {
+			const boilerplate = Forms.init('#element');
+			proclaim.equal(boilerplate instanceof Forms, true);
+		});
+	});
+});


### PR DESCRIPTION
Adds the ability to validate forms based on the Constraint Validation API in browsers, applying the appropriate `o-forms` classes when an error has occurred and preventing Safari from submitting a form if errors are present (other browsers do this as standard).

Also updates readme to fit Origami structure.