### PR TITLE
Implemented new design using latest o-colors and o-typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,12 @@ There are a number of inconsistencies in how browsers handle form events, valida
 
 ## Migration Guide
 
-Upgrading from v1.x.x or v2.x.x? [Follow these instructions](#upgrade-to-v3).
-Upgrading from v0.x.x? [Follow these instructions](#upgrade-to-v1).
+## Upgrading from v3.x.x or v4.x.x
+- A dependency on [o-typography](http://github.com/financial-times/o-icons) v5 has been introduced. This will break any builds that use o-typography <v5. __Resolution__: Update to o-typography v5.
+- The o-colors dependency has been updated to `^4`. This could create bower conflicts which should be resolved by updating to the newest release of o-colors.
+- The design for o-forms has changed in v4. This could create issues on your pages which make use of o-forms. Ensure that the updated design does not break the layout on your webpage.
 
-<a name="upgrade-to-v3"></a>
+----
 
 ## Upgrading from v2.x.x or v3.x.x
 
@@ -296,8 +298,6 @@ Any modifier classes like `o-forms--error` have remained the same.
 
 
 ----
-
-<a name="upgrade-to-v1"></a>
 
 ## Upgrading from 0.x.x
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "o-colors": "^4",
     "o-grid": "^4.0.0",
-    "o-normalise": "^1.2.0"
+    "o-normalise": "^1.2.0",
+    "o-typography": "^5.0.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,11 @@
 {
   "name": "o-forms",
   "main": [
-    "main.scss"
+    "main.scss",
+    "main.js"
   ],
   "dependencies": {
-    "o-colors": ">=2.5.0 <4",
+    "o-colors": "^4",
     "o-grid": "^4.0.0",
     "o-normalise": "^1.2.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "main.js"
   ],
   "dependencies": {
-    "o-colors": "^4",
+    "o-colors": "^4.0.0",
     "o-grid": "^4.0.0",
     "o-normalise": "^1.2.0",
     "o-typography": "^5.0.1"

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -8,5 +8,5 @@ html {
 
 body {
 	margin: oGridGutter();
-	background-color: oColorsGetPaletteColor('pink');
+	background-color: oColorsGetPaletteColor('paper');
 }

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,4 @@
+@import 'o-typography/main';
 @import "o-normalise/main";
 @import "o-colors/main";
 @import "o-grid/main";

--- a/origami.json
+++ b/origami.json
@@ -49,10 +49,7 @@
         {
             "name": "prefix-suffix",
             "template": "/demos/src/prefix-suffix.mustache",
-            "description": "",
-            "dependencies": [
-                "o-buttons@^4.3.0"
-            ]
+            "description": ""
         },
         {
             "name": "messages",
@@ -70,10 +67,7 @@
             "name": "pa11y",
             "template": "/demos/src/pa11y.mustache",
             "hidden": true,
-            "description": "",
-            "dependencies": [
-                "o-buttons@^4.3.0"
-            ]
+            "description": ""
         },
         {
             "name": "js-validation",
@@ -86,7 +80,8 @@
         "sass": "demos/src/demo.scss",
         "js": "demos/src/demo.js",
         "dependencies": [
-            "o-fonts@^1.4.0"
+            "o-fonts@^3",
+            "o-buttons@^4.3.0"
         ]
     }
 }

--- a/origami.json
+++ b/origami.json
@@ -70,7 +70,10 @@
             "name": "pa11y",
             "template": "/demos/src/pa11y.mustache",
             "hidden": true,
-            "description": ""
+            "description": "",
+            "dependencies": [
+                "o-buttons@^4.3.0"
+            ]
         },
         {
             "name": "js-validation",

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,31 +1,31 @@
-@include oColorsSetUseCase(o-forms__message-default, text, 'grey-tint5');
-@include oColorsSetUseCase(o-forms__message-error, background, 'red');
+@include oColorsSetUseCase(o-forms__message-default, text, 'black-80');
+@include oColorsSetUseCase(o-forms__message-error, background, 'crimson');
 @include oColorsSetUseCase(o-forms__message-error, text, 'white');
-@include oColorsSetUseCase(o-forms__message-error-fallback, background, 'red-tint5');
+@include oColorsSetUseCase(o-forms__message-error-fallback, background, 'crimson-tint5');
 
-@include oColorsSetUseCase(o-forms__wrapper-highlight, background, 'pink-tint2');
+@include oColorsSetUseCase(o-forms__wrapper-highlight, background, 'black-10');
 
-@include oColorsSetUseCase(o-forms-field-label, text, 'grey-tint4');
+@include oColorsSetUseCase(o-forms-field-label, text, 'black-70');
 
-@include oColorsSetUseCase(o-forms-field-additional-info, text, 'grey-tint5');
+@include oColorsSetUseCase(o-forms-field-additional-info, text, 'black-80');
 
-@include oColorsSetUseCase(o-forms__prefixsuffix, background, 'pink-tint1');
-@include oColorsSetUseCase(o-forms__prefixsuffix, text, 'pink-tint5');
+@include oColorsSetUseCase(o-forms__prefixsuffix, background, 'black-5');
+@include oColorsSetUseCase(o-forms__prefixsuffix, text, 'black-50');
 
-@include oColorsSetUseCase(o-forms-field-standard, text, 'grey-tint5');
-@include oColorsSetUseCase(o-forms-field-standard, border, 'pink-tint3');
+@include oColorsSetUseCase(o-forms-field-standard, text, 'black-80');
+@include oColorsSetUseCase(o-forms-field-standard, border, 'black-20');
 @include oColorsSetUseCase(o-forms-field-standard, background, 'white');
 
-@include oColorsSetUseCase(o-forms-field-disabled, border, 'pink-tint2');
-@include oColorsSetUseCase(o-forms-field-disabled, background, 'pink-tint2');
+@include oColorsSetUseCase(o-forms-field-disabled, border, 'black-10');
+@include oColorsSetUseCase(o-forms-field-disabled, background, 'black-10');
 
-@include oColorsSetUseCase(o-forms-field-focus, border, 'pink-tint4');
-@include oColorsSetUseCase(o-forms-focus-ring, border, 'teal-2');
+@include oColorsSetUseCase(o-forms-field-focus, border, 'black-30');
+@include oColorsSetUseCase(o-forms-focus-ring, border, 'teal-80');
 
-@include oColorsSetUseCase(o-forms-field-valid, text, 'grey-tint5');
-@include oColorsSetUseCase(o-forms-field-valid, border, 'green');
+@include oColorsSetUseCase(o-forms-field-valid, text, 'black-80');
+@include oColorsSetUseCase(o-forms-field-valid, border, 'jade');
 @include oColorsSetUseCase(o-forms-field-valid, background, 'white');
 
-@include oColorsSetUseCase(o-forms-field-invalid, text, 'red');
-@include oColorsSetUseCase(o-forms-field-invalid, border, 'red');
+@include oColorsSetUseCase(o-forms-field-invalid, text, 'crimson');
+@include oColorsSetUseCase(o-forms-field-invalid, border, 'crimson');
 @include oColorsSetUseCase(o-forms-field-invalid, background, 'white');

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -13,18 +13,21 @@
 @include oColorsSetUseCase(o-forms__prefixsuffix, text, 'black-50');
 
 @include oColorsSetUseCase(o-forms-field-standard, text, 'black-80');
-@include oColorsSetUseCase(o-forms-field-standard, border, 'black-20');
+@include oColorsSetUseCase(o-forms-field-standard, border, 'black-30');
 @include oColorsSetUseCase(o-forms-field-standard, background, 'white');
 
+@include oColorsSetUseCase(o-forms-field-placholder, text, 'black-60');
+
+@include oColorsSetUseCase(o-forms-field-disabled, text, 'black-60');
 @include oColorsSetUseCase(o-forms-field-disabled, border, 'black-10');
 @include oColorsSetUseCase(o-forms-field-disabled, background, 'black-10');
 
-@include oColorsSetUseCase(o-forms-field-focus, border, 'black-30');
+@include oColorsSetUseCase(o-forms-field-focus, border, 'black-40');
 @include oColorsSetUseCase(o-forms-focus-ring, border, 'teal-80');
 
-@include oColorsSetUseCase(o-forms-field-valid, text, 'black-80');
+@include oColorsSetUseCase(o-forms-field-valid, text, 'jade');
 @include oColorsSetUseCase(o-forms-field-valid, border, 'jade');
-@include oColorsSetUseCase(o-forms-field-valid, background, 'white');
+@include oColorsSetUseCase(o-forms-field-valid, background, 'jade');
 
 @include oColorsSetUseCase(o-forms-field-invalid, text, 'crimson');
 @include oColorsSetUseCase(o-forms-field-invalid, border, 'crimson');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -21,23 +21,22 @@ $_o-forms-field-border-radius: $o-normalise-border-radius;
 
 $_o-forms-field-default-font-size: 14px;
 
-$_o-forms-field-default-padding-leftright: 5px;
+$_o-forms-field-default-padding-leftright: 10px;
 $_o-forms-field-default-padding-top: 10px;
 $_o-forms-field-default-padding-bottom: 10px;
 $_o-forms-field-default-height: 38px;
 
-$_o-forms-field-small-height: 24px;
-$_o-forms-field-small-padding-topbottom: 3px;
+$_o-forms-field-small-height: 28px; // align it to the regular button size
 
-$_o-forms-field-max-width: 400px;
+$_o-forms-field-max-width: 380px; // This is meant to be 1/3 of the columns in the full grid, should probably be using an o-grid function
 
 $_o-forms-padding: oGridGutter();
 
 // Outer circle / box sizes
-$_o-forms__radiocheckbox-default-size: 14px;
+$_o-forms__radiocheckbox-default-size: 24px;
 
 // Inner circle sizes
-$_o-forms__radio-internal-default-size: 6px;
+$_o-forms__radio-internal-default-size: 12px;
 
 $_o-forms__label-margin-bottom: 4px;
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -21,7 +21,7 @@ $_o-forms-field-border-radius: $o-normalise-border-radius;
 
 $_o-forms-field-default-font-size: 14px;
 
-$_o-forms-field-default-padding-leftright: 10px;
+$_o-forms-field-default-padding-leftright: 8px;
 $_o-forms-field-default-padding-top: 10px;
 $_o-forms-field-default-padding-bottom: 10px;
 $_o-forms-field-default-height: 38px;

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -42,7 +42,7 @@
 /// Common field styles: focused state only
 @mixin oFormsCommonFieldFocus {
 	@include oColorsFor(o-forms-field-focus);
-	box-shadow: inset 0 0 4px 1px oColorsGetColorFor(o-forms-focus-ring, border);
+	box-shadow: 0 0 0 2px oColorsGetColorFor(o-forms-focus-ring, border);
 }
 
 /// Common field styles: disabled state
@@ -56,7 +56,7 @@
 	@include oColorsFor(o-forms-field-invalid);
 
 	&:focus {
-		box-shadow: inset 0 0 4px 1px rgba(oColorsGetColorFor(o-forms-field-invalid, border), 0.3);
+		box-shadow: 0 0 0 2px oColorsGetColorFor(o-forms-field-invalid, border);
 	}
 }
 

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -71,7 +71,7 @@
 @mixin oFormsCommonSmall {
 	height: $_o-forms-field-small-height;
 	padding-top: 0;
-	padding-bottom: 0;
+	padding-bottom: 2px;
 	background-size: $_o-forms-select-small-iconsize;
 	line-height: $_o-forms-field-small-height - ($_o-forms-field-border-width * 2);
 }

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -9,7 +9,7 @@
 	width: 100%;
 	max-width: $_o-forms-field-max-width;
 	height: $_o-forms-field-default-height;
-	margin: 0;
+	@include oTypographyMargin($top: 3);
 	padding: $_o-forms-field-default-padding-top $_o-forms-field-default-padding-leftright $_o-forms-field-default-padding-bottom;
 	border: $_o-forms-field-border;
 	border-radius: $_o-forms-field-border-radius;
@@ -33,19 +33,22 @@
 	&:disabled {
 		@include oFormsCommonFieldDisabled;
 	}
+
+	&::placeholder {
+		color: oColorsGetColorFor(o-forms-field-placholder, text);
+	}
 }
 
 /// Common field styles: focused state only
 @mixin oFormsCommonFieldFocus {
 	@include oColorsFor(o-forms-field-focus);
-	box-shadow: inset 0 0 4px 1px rgba(oColorsGetColorFor(o-forms-focus-ring, border), 0.7);
+	box-shadow: inset 0 0 4px 1px oColorsGetColorFor(o-forms-focus-ring, border);
 }
 
 /// Common field styles: disabled state
 @mixin oFormsCommonFieldDisabled {
 	@include oColorsFor(o-forms-field-disabled);
 	cursor: default;
-	color: #afafaf;
 }
 
 /// Common field styles: invalid state
@@ -60,6 +63,8 @@
 /// Common field styles: valid state
 @mixin oFormsCommonFieldValid {
 	border-color: oColorsGetColorFor(o-forms-field-valid, border);
+	background-color: rgba(oColorsGetColorFor(o-forms-field-valid, background), 0.05);
+	color: oColorsGetColorFor(o-forms-field-valid, text);
 }
 
 /// Common field styles: small

--- a/src/scss/mixins/_labels.scss
+++ b/src/scss/mixins/_labels.scss
@@ -1,11 +1,8 @@
 /// Label styles
 @mixin oFormsLabel {
 	display: block;
-	margin-bottom: $_o-forms__label-margin-bottom;
 	padding: 0; // Reset legend default styling
-	font-size: 18px;
-	line-height: 22px;
-	font-weight: 600;
+	@include oTypographySansBold(1);
 	color: oColorsGetColorFor(o-forms-field-label body, text);
 
 	p {
@@ -20,11 +17,8 @@
 /// Additional info
 @mixin oFormsAdditionalInfo {
 	display: block;
-	margin-top: -2px;
-	margin-bottom: 4px;
 	color: oColorsGetColorFor(o-forms-field-additional-info body, text);
-	font-size: 14px;
-	line-height: 18px;
+	@include oTypographySans(0);
 }
 
 /// Error text

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -30,7 +30,7 @@
 		padding-left: $_o-forms__radiocheckbox-default-size + 16px; // radio/checkboxes are being styled as pseudo-elements, which means we have to account for the width of the radio/checkboxes when adding padding to the labels
 		position: relative;
 		cursor: pointer;
-		@include oTypographySans($scale: -1, $line-height: 15px);
+		@include oTypographySans($scale: -1);
 		font-weight: 400;
 		padding-top: 4px; // To align the text with the center of the checkbox/radio
 		// sass-lint:disable no-vendor-prefixes

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -25,14 +25,14 @@
 	#{$checkbox} + #{$label},
 	#{$radio} + #{$label} {
 		display: inline-block;
-		margin-top: $_o-forms__label-margin-bottom; // double the spacing between labels and radio/checkboxes
+		@include oTypographyMargin($top: 3, $bottom: 3);
 		margin-right: 15px;
-		padding-left: $_o-forms__radiocheckbox-default-size + 5px;
+		padding-left: $_o-forms__radiocheckbox-default-size + 16px; // radio/checkboxes are being styled as pseudo-elements, which means we have to account for the width of the radio/checkboxes when adding padding to the labels
 		position: relative;
 		cursor: pointer;
-		font-size: 14px;
+		@include oTypographySans($scale: -1, $line-height: 15px);
 		font-weight: 400;
-		line-height: $_o-forms__radiocheckbox-default-size + 1px;
+		padding-top: 4px; // To align the text with the center of the checkbox/radio
 		// sass-lint:disable no-vendor-prefixes
 		-moz-user-select: none;
 		-webkit-user-select: none;
@@ -55,21 +55,19 @@
 		left: 0;
 		width: $_o-forms__radiocheckbox-default-size;
 		height: $_o-forms__radiocheckbox-default-size;
-		border: 1px solid oColorsGetColorFor(o-forms-field-standard, border);
+		border: 2px solid oColorsGetColorFor(o-forms-field-standard, border);
+		@include oColorsFor(o-forms-field-focus);
 		box-sizing: border-box;
 		content: '';
 		background-color: oColorsGetColorFor(o-forms-field-standard, background);
 		transition: all 0.1s ease-in;
 	}
 
-	#{$checkbox} + #{$label}::before,
-	#{$checkbox} + #{$label}::after {
-		border-radius: 3px;
-	}
-
 	// Apply different border colour to checkboxes and radio labels on focus
 	#{$checkbox}:focus + #{$label}::before,
-	#{$radio}:focus + #{$label}::before {
+	#{$radio}:focus + #{$label}::before,
+	#{$checkbox}:focus + #{$label}::after,
+	#{$radio}:focus + #{$label}::after {
 		@include oFormsCommonFieldFocus;
 	}
 
@@ -104,8 +102,13 @@
 		opacity: 1;
 	}
 
+	#{$radio}:checked + #{$label}::before {
+		// Outer ring changes to teal when the radio button is checked
+		border: 2px solid oColorsGetPaletteColor('teal');
+	}
+
 	#{$radio} + #{$label}::after {
-		background-color: oColorsGetPaletteColor('black-70');
+		background-color: oColorsGetPaletteColor('teal');
 		border-radius: 50%;
 		height: $_o-forms__radio-internal-default-size;
 		width: $_o-forms__radio-internal-default-size;
@@ -114,9 +117,10 @@
 	}
 
 	#{$checkbox} + #{$label}::after {
-		$check-color: oColorsGetPaletteColor('black-80');
+		$check-color: oColorsGetPaletteColor('white');
 		background-image: url(str-replace("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:tick?source=o-icons&tint=%23#{$check-color}&format=svg", "#", ""));
 		background-repeat: no-repeat;
+		background-color: oColorsGetPaletteColor('teal');
 		height: $_o-forms__radiocheckbox-default-size;
 		width: $_o-forms__radiocheckbox-default-size;
 		background-size: $_o-forms__radiocheckbox-default-size;

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -65,9 +65,7 @@
 
 	// Apply different border colour to checkboxes and radio labels on focus
 	#{$checkbox}:focus + #{$label}::before,
-	#{$radio}:focus + #{$label}::before,
-	#{$checkbox}:focus + #{$label}::after,
-	#{$radio}:focus + #{$label}::after {
+	#{$radio}:focus + #{$label}::before {
 		@include oFormsCommonFieldFocus;
 	}
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -105,7 +105,7 @@
 	}
 
 	#{$radio} + #{$label}::after {
-		background-color: oColorsGetPaletteColor('grey-tint4');
+		background-color: oColorsGetPaletteColor('black-70');
 		border-radius: 50%;
 		height: $_o-forms__radio-internal-default-size;
 		width: $_o-forms__radio-internal-default-size;
@@ -114,7 +114,7 @@
 	}
 
 	#{$checkbox} + #{$label}::after {
-		$check-color: oColorsGetPaletteColor('grey-tint5');
+		$check-color: oColorsGetPaletteColor('black-80');
 		background-image: url(str-replace("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:tick?source=o-icons&tint=%23#{$check-color}&format=svg", "#", ""));
 		background-repeat: no-repeat;
 		height: $_o-forms__radiocheckbox-default-size;

--- a/src/scss/mixins/_select.scss
+++ b/src/scss/mixins/_select.scss
@@ -43,6 +43,11 @@
 		color: oColorsGetPaletteColor('white');
 	}
 	// sass-lint:enable no-vendor-prefixes
+
+	&:disabled {
+		$icon-color: oColorsGetPaletteColor('black-60');
+		background-image: url(str-replace("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrows-up-down?source=o-icons&tint=%23#{$icon-color}&format=svg", "#", ""));
+	}
 }
 
 @mixin oFormsSelectMulti() {

--- a/src/scss/mixins/_select.scss
+++ b/src/scss/mixins/_select.scss
@@ -2,9 +2,9 @@
 ///
 /// To be used in combination with oFormsCommonField
 @mixin oFormsSelect {
-	$icon-color: oColorsGetPaletteColor('grey-tint5');
+	$icon-color: oColorsGetPaletteColor('black-80');
 	cursor: pointer;
-	color: oColorsGetPaletteColor('grey-tint5');
+	color: oColorsGetPaletteColor('black-80');
 	background-image: url(str-replace("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrows-up-down?source=o-icons&tint=%23#{$icon-color}&format=svg", "#", ""));
 	// For iOS 6 that doesn't support 4-value background-position
 	// sass-lint:disable no-duplicate-properties

--- a/src/scss/prefix-suffix.scss
+++ b/src/scss/prefix-suffix.scss
@@ -66,8 +66,26 @@
 	}
 }
 
+@mixin oFormsAffixCheckbox($class: 'o-forms') {
+	// .#{$class}__label
+	.#{$class}__prefix .#{$class}__checkbox + .#{$class}__label::before,
+	.#{$class}__suffix .#{$class}__checkbox + .#{$class}__label::before,
+	.#{$class}__prefix .#{$class}__checkbox + .#{$class}__label::after,
+	.#{$class}__suffix .#{$class}__checkbox + .#{$class}__label::after {
+		top: -3px;
+		left: -4px;
+	}
+
+	.#{$class}__prefix .#{$class}__checkbox + .#{$class}__label,
+	.#{$class}__suffix .#{$class}__checkbox + .#{$class}__label {
+		padding-left: 30px;
+		padding-top: 2px;
+	}
+}
+
 @mixin oFormsPrefixSuffix($class: 'o-forms', $support-button: true) {
 	@include oFormsAffixWrapper($class);
+	@include oFormsAffixCheckbox($class);
 
 	.#{$class}__prefix,
 	.#{$class}__suffix {

--- a/src/scss/prefix-suffix.scss
+++ b/src/scss/prefix-suffix.scss
@@ -3,6 +3,13 @@
 		display: table;
 		width: 100%;
 		box-sizing: border-box;
+		@include oTypographyMargin($top: 1);
+	}
+
+	.#{$class}__affix-wrapper .#{$class}__text,
+	.#{$class}__affix-wrapper .#{$class}__select,
+	.#{$class}__affix-wrapper .#{$class}__textarea {
+		@include oTypographyMargin($top: 0);
 	}
 
 	.#{$class}__affix-wrapper .#{$class}__text,
@@ -67,6 +74,7 @@
 		display: table-cell;
 		vertical-align: top;
 		box-sizing: border-box;
+		@include oTypographyMargin($top: 1);
 		width: 1%;
 		white-space: nowrap;
 		border-top: $_o-forms-field-border;
@@ -89,6 +97,7 @@
 		border-right: 0;
 		border-top-left-radius: $_o-forms-field-border-radius;
 		border-bottom-left-radius: $_o-forms-field-border-radius;
+		@include oTypographyMargin($top: 1);
 	}
 
 	.#{$class}__suffix {

--- a/src/scss/unskin.scss
+++ b/src/scss/unskin.scss
@@ -11,7 +11,7 @@
 		box-shadow: none !important;
 
 		// for iOS
-		-webkit-text-fill-color: oColorsGetPaletteColor('grey-tint5') !important;
+		-webkit-text-fill-color: oColorsGetPaletteColor('black-80') !important;
 		opacity: 1 !important;
 		border-radius: 0 !important;
 		// sass-lint:disable no-vendor-prefixes no-important


### PR DESCRIPTION
I'm still working on the migration guide, opening pull request to get feedback on what has been done.

Old:
![0 0 0 0-8081-demos-local-pa11y html](https://user-images.githubusercontent.com/1569131/26881831-861048f2-4b90-11e7-9820-6b7f85ac358f.png)
New:
![www ft com-__origami-service-build-v2-demos-o-forms 3 5 0-pa11y](https://user-images.githubusercontent.com/1569131/26881845-90fa5cee-4b90-11e7-82d6-b0cd727dabd6.png)

