### PR TITLE
hide errortext until error modifier is used on the form

### DIFF
--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -55,6 +55,10 @@
 	}
 
 	.#{$class}__errortext {
+		display: none;
+	}
+
+	.#{$class}--error .#{$class}__errortext {
 		@include oFormsErrorText;
 	}
 }


### PR DESCRIPTION
potentially breaking change but looks like most origami users are already doing this inside their own css