### PR TITLE
Fix bug in ie11 that hid icons in input fields

### DIFF
--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -72,7 +72,7 @@
 	height: $_o-forms-field-small-height;
 	padding-top: 0;
 	padding-bottom: 2px;
-	background-size: $_o-forms-select-small-iconsize;
+	background-size: $_o-forms-select-small-iconsize $_o-forms-select-small-iconsize;
 	background-position-x: 99%; // Make the smaller icon size visually match the padding on the left of the input
 	line-height: $_o-forms-field-small-height - ($_o-forms-field-border-width * 2);
 }

--- a/src/scss/mixins/_select.scss
+++ b/src/scss/mixins/_select.scss
@@ -13,7 +13,7 @@
 	// sass-lint:enable no-duplicate-properties
 	background-repeat: no-repeat;
 	background-origin: border-box;
-	background-size: $_o-forms__select-iconsize;
+	background-size: $_o-forms__select-iconsize $_o-forms__select-iconsize;
 	padding-right: $_o-forms__select-iconsize;
 	padding-top: $_o-forms-field-default-padding-bottom - 2px;
 


### PR DESCRIPTION
The down arrow indicating a drop-down menu inside an input field was invisible on IE11, as raised by this issue: https://github.com/Financial-Times/o-forms/issues/143

This fix makes it visible on IE and other browsers so it appears as it should: 
<img width="404" alt="screen shot 2017-09-25 at 16 22 18" src="https://user-images.githubusercontent.com/10324129/30816398-c94f72cc-a20d-11e7-817d-8ced3707eda8.png">
