### PR TITLE
Reinstate removed o-forms__prefix and o-forms__suffix styles.

### DIFF
--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -217,4 +217,12 @@
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	// sass-lint:enable no-vendor-prefixes
+
+	// When in a prefix/suffix, clear the margins
+	// and reduce the font size
+	.o-forms__prefix &,
+	.o-forms__suffix & {
+		margin: 0;
+		font-size: 12px;
+	}
 }


### PR DESCRIPTION
I mistakenly removed these here (released in `o-forms@4.1.0`) 😞:
https://github.com/Financial-Times/o-forms/pull/155/files

Causing this issue:
https://github.com/Financial-Times/o-forms/issues/161
