### PR TITLE
Fix IE9 suffix bug

### DIFF
--- a/src/scss/suffix.scss
+++ b/src/scss/suffix.scss
@@ -11,24 +11,6 @@
 	.#{$class}__affix-wrapper .#{$class}__textarea {
 		@include oTypographyMargin($top: 0);
 	}
-
-	.#{$class}__affix-wrapper .#{$class}__text,
-	.#{$class}__affix-wrapper .#{$class}__select {
-		display: table-cell;
-		border-radius: 0;
-	}
-
-	.#{$class}__affix-wrapper .#{$class}__text:first-child,
-	.#{$class}__affix-wrapper .#{$class}__select:first-child {
-		border-top-left-radius: $_o-forms-field-border-radius;
-		border-bottom-left-radius: $_o-forms-field-border-radius;
-	}
-
-	.#{$class}__affix-wrapper .#{$class}__text:last-child,
-	.#{$class}__affix-wrapper .#{$class}__select:last-child {
-		border-top-right-radius: $_o-forms-field-border-radius;
-		border-bottom-right-radius: $_o-forms-field-border-radius;
-	}
 }
 
 @mixin oFormsSuffix($class: 'o-forms') {
@@ -48,6 +30,9 @@
 		-webkit-user-select: none;
 		-ms-user-select: none;
 		// sass-lint:enable no-vendor-prefixes
+		> * {
+			display: table-cell; // IE9 hack for child with min-width & border-box
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes a suffix bug in IE9 which effected the select dropdown and spacing... this PR also removes some -- what appears to be -- redundant css `border-top-left-radius`.

The workaround for the spacing issue, making any child of the suffix display as a table cell, is gross. The problem occurs in IE9 if the child has no explicit width and `box-sizing: border-box`. The extra space leaves enough room for the child to be displayed as if it were not set to `box-sizing: border-box`. 🤔 

before
<img width="422" alt="screen shot 2018-01-23 at 18 41 43" src="https://user-images.githubusercontent.com/10405691/35293918-189bbd32-006d-11e8-90a2-ef4bbd96ced9.png">

after
<img width="432" alt="screen shot 2018-01-23 at 18 35 53" src="https://user-images.githubusercontent.com/10405691/35293870-f43f912a-006c-11e8-9a49-9fb3b9d6ffb3.png">
