### PR TITLE
Input text vertical spacing

### DIFF
--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -29,7 +29,6 @@
 	box-sizing: border-box;
 	width: 100%;
 	max-width: $_o-forms-field-max-width;
-	height: $_o-forms-field-default-height;
 	padding: $_o-forms-field-default-padding-top $_o-forms-field-default-padding-leftright $_o-forms-field-default-padding-bottom;
 	border: $_o-forms-field-border;
 	border-radius: $_o-forms-field-border-radius;
@@ -86,9 +85,8 @@
 /// @access public
 /// @output Shared styles to make an input smaller, e.g select or text.
 @mixin oFormsCommonSmall {
-	height: $_o-forms-field-small-height;
 	padding-top: 0;
-	padding-bottom: 2px;
+	padding-bottom: 0;
 	background-size: $_o-forms-select-small-iconsize $_o-forms-select-small-iconsize;
 	background-position-x: 99%; // Make the smaller icon size visually match the padding on the left of the input
 	line-height: $_o-forms-field-small-height - ($_o-forms-field-border-width * 2);


### PR DESCRIPTION
James spotted an alignment issue. The text within a form input is not quite centred. Oddly (I don't know why) this can be avoided by not setting a height. Instead we will rely on padding to produce the correct height.

Wait for it...

![kapture 2018-01-31 at 12 01 37](https://user-images.githubusercontent.com/10405691/35622473-de703aac-067f-11e8-891d-90ec1191f3b6.gif)
