### PR TITLE
Correct select input height

### DIFF
--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -29,6 +29,7 @@
 	box-sizing: border-box;
 	width: 100%;
 	max-width: $_o-forms-field-max-width;
+	min-height: $_o-forms-field-default-height;
 	padding: $_o-forms-field-default-padding-top $_o-forms-field-default-padding-leftright $_o-forms-field-default-padding-bottom;
 	border: $_o-forms-field-border;
 	border-radius: $_o-forms-field-border-radius;
@@ -87,6 +88,7 @@
 @mixin oFormsCommonSmall {
 	padding-top: 0;
 	padding-bottom: 0;
+	min-height: $_o-forms-field-small-height;
 	background-size: $_o-forms-select-small-iconsize $_o-forms-select-small-iconsize;
 	background-position-x: 99%; // Make the smaller icon size visually match the padding on the left of the input
 	line-height: $_o-forms-field-small-height - ($_o-forms-field-border-width * 2);


### PR DESCRIPTION
This https://github.com/Financial-Times/o-forms/pull/181 negatively impacted select box height. Rather than restore height we can use min-height to defend against this.

Before
<img width="413" alt="screen shot 2018-01-31 at 15 59 25" src="https://user-images.githubusercontent.com/10405691/35633054-42127af0-06a0-11e8-9a0b-25e5cbf860ef.png">

After
<img width="396" alt="screen shot 2018-01-31 at 16 02 41" src="https://user-images.githubusercontent.com/10405691/35633060-45847b02-06a0-11e8-8e0c-6dd0a61c1feb.png">
