### PR TITLE
Remove placeholders from demos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each form field is made up of at least 3 elements:
 ```html
 <div class="o-forms">
 	<label for="o-forms-demo-text" class="o-forms__label">Text input example</label>
-	<input type="text" id="o-forms-demo-text" placeholder="placeholder" class="o-forms__text" required />
+	<input type="text" id="o-forms-demo-text" class="o-forms__text" required />
 </div>
 ```
 
@@ -37,7 +37,7 @@ It is possible to add additional information to form fields with `.o-forms__addi
 <div class="o-forms">
 	<label for="o-forms-demo-additional" class="o-forms__label">Text input example</label>
 	<div class="o-forms__additional-info">Additional info follows the label if required.</div>
-	<input type="text" id="o-forms-demo-additional" placeholder="placeholder" class="o-forms__text" required />
+	<input type="text" id="o-forms-demo-additional" class="o-forms__text" required />
 </div>
 ```
 
@@ -48,7 +48,7 @@ To indicate to the user that a field is optional, add the `.o-forms__label--opti
 ```html
 <div class="o-forms">
 	<label for="o-forms-demo-optional" class="o-forms__label o-forms__label--optional">Optional  input example</label>
-	<input type="text" id="o-forms-demo-optional" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" id="o-forms-demo-optional" class="o-forms__text" />
 </div>
 ```
 
@@ -59,7 +59,7 @@ The class `.o-forms--wide` can be used to show form fields without width restric
 ```html
 <div class="o-forms o-forms--wide">
 	<label for="o-forms-full" class="o-forms__label">Text input full width</label>
-	<input type="text" placeholder="placeholder" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
+	<input type="text" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 ```
 
@@ -72,7 +72,7 @@ The markup above demonstrates how to use text inputs. More [text input examples]
 ```html
 <div class="o-forms">
 	<label for="o-forms-demo-textarea" class="o-forms__label">Textarea</label>
-	<textarea placeholder="Placeholder" id="o-forms-demo-textarea" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms-demo-textarea" class="o-forms__textarea"></textarea>
 </div>
 ```
 
@@ -185,7 +185,7 @@ Suffixes are used to append content to an input, i.e. a button. Add a wrapper `.
 <div class="o-forms">
 	<label class="o-forms__label" for="text-suffix">Text input with suffix button</label>
 	<div class="o-forms__affix-wrapper">
-		<input id="text-suffix" type="text" placeholder="placeholder" class="o-forms__text" />
+		<input id="text-suffix" type="text" class="o-forms__text" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons o-buttons--secondary o-buttons--big">Go</button>
 		</div>
@@ -228,7 +228,7 @@ An error message, defined with `.o-forms__errortext`, can be appended to the con
 ```html
 <div class="o-forms o-forms--error">
 	<label class="o-forms__label">Text input</label>
-	<input type="text" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" class="o-forms__text" />
 	<div class="o-forms__errortext">Please enter a valid url</div>
 </div>
 ```
@@ -244,7 +244,7 @@ Wrap a group of `.o-forms` fields in a section `.o-forms-section` to highlight t
 	</div>
 	<div class="o-forms">
 		<label for="o-forms-message" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-message" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-message" class="o-forms__text" required />
 	</div>
 </div>
 ```
@@ -258,7 +258,7 @@ This can be used to highlight errors within a section of a form which contains m
 	</div>
 	<div class="o-forms o-forms--error">
 		<label for="o-forms-section-error" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-section-error" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-section-error" class="o-forms__text" required />
 		<div class="o-forms__errortext">Invalid entry</div>
 	</div>
 </div>

--- a/demos/src/checkboxes.mustache
+++ b/demos/src/checkboxes.mustache
@@ -26,7 +26,7 @@
 <div class="o-forms">
 	<label for="form-secret" class="o-forms__label">Right side control checkbox</label>
 	<div class="o-forms__additional-info">Interface demo only, password hide/show functionality is not currently included in o-forms.</div>
-	<input type="password" id="form-secret" placeholder="secret password" class="o-forms__text" required />
+	<input type="password" id="form-secret" class="o-forms__text" required />
 	<div class="o-forms__group o-forms__group--inline">
 		<input type="checkbox" name="checkbox" value="2" class="o-forms__checkbox o-forms__checkbox--right" id="controlCheckbox" />
 		<label for="controlCheckbox" class="o-forms__label">Show password</label>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -52,7 +52,7 @@
 <div class="o-forms">
 	<label for="form-secret" class="o-forms__label">Right side control checkbox</label>
 	<div class="o-forms__additional-info">Interface demo only, password hide/show functionality is not currently included in o-forms.</div>
-	<input type="password" id="form-secret" placeholder="secret password" class="o-forms__text" required />
+	<input type="password" id="form-secret" class="o-forms__text" required />
 	<div class="o-forms__group o-forms__group--inline">
 		<input type="checkbox" name="checkbox" value="2" class="o-forms__checkbox o-forms__checkbox--right" id="controlCheckbox" />
 		<label for="controlCheckbox" class="o-forms__label">Show password</label>
@@ -209,7 +209,7 @@
 <div class="o-forms">
 	<label class="o-forms__label" for="text-suffix">Text input with suffix button</label>
 	<div class="o-forms__affix-wrapper">
-		<input id="text-suffix" type="text" placeholder="placeholder" class="o-forms__text" />
+		<input id="text-suffix" type="text" class="o-forms__text" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons o-buttons--secondary o-buttons--big">Go</button>
 		</div>
@@ -234,7 +234,7 @@
 <div class="o-forms">
 	<label class="o-forms__label" for="small-text-suffix">Small text input with suffix button</label>
 	<div class="o-forms__affix-wrapper">
-		<input id="small-text-suffix" type="text" placeholder="placeholder" class="o-forms__text o-forms__text--small" />
+		<input id="small-text-suffix" type="text" class="o-forms__text o-forms__text--small" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons o-buttons--secondary">Go</button>
 		</div>
@@ -259,71 +259,71 @@
 <div class="o-forms">
 	<label for="o-forms-standard" class="o-forms__label">Text input</label>
 	<div class="o-forms__additional-info">Prompt text follows the label if required..</div>
-	<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" required />
+	<input type="text" id="o-forms-standard" class="o-forms__text" required />
 </div>
 
 <div class="o-forms">
 	<label for="o-forms-optional" class="o-forms__label o-forms__label--optional">Optional text input</label>
-	<input type="text" id="o-forms-optional" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" id="o-forms-optional" class="o-forms__text" />
 </div>
 
 <div class="o-forms o-forms--valid">
 	<label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
-	<input type="text" placeholder="placeholder" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
+	<input type="text" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 
 <div class="o-forms o-forms--error">
 	<label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
-	<input type="url" placeholder="placeholder" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
+	<input type="url" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
 	<div class="o-forms__errortext">Please enter a valid url</div>
 </div>
 
 <div class="o-forms">
 	<label for="o-forms-disabled" class="o-forms__label">Text input disabled</label>
-	<input type="text" placeholder="placeholder" id="o-forms-disabled" class="o-forms__text o-forms__text--valid" value="Field value" disabled="disabled" />
+	<input type="text" id="o-forms-disabled" class="o-forms__text o-forms__text--valid" value="Field value" disabled="disabled" />
 </div>
 
 <div class="o-forms o-forms--wide">
 	<label for="o-forms-full" class="o-forms__label">Text input full width</label>
-	<input type="text" placeholder="placeholder" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
+	<input type="text" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 
 <div class="o-forms">
 	<label for="o-forms-small" class="o-forms__label">Text input small</label>
-	<input type="text" id="o-forms-small" placeholder="placeholder" class="o-forms__text o-forms__text--small" />
+	<input type="text" id="o-forms-small" class="o-forms__text o-forms__text--small" />
 </div>
 
 <div class="o-forms">
 	<label for="o-forms__textarea" class="o-forms__label">Textarea</label>
 	<div class="o-forms__additional-info">Prompt text follows the label if required.</div>
-	<textarea placeholder="Placeholder" id="o-forms__textarea" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
 </div>
 
 <div class="o-forms">
 	<label for="o-forms__textarea-optional" class="o-forms__label o-forms__label--optional">Optional textarea</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-optional" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea-optional" class="o-forms__textarea"></textarea>
 </div>
 
 <div class="o-forms o-forms--error">
 	<label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
 	<div class="o-forms__errortext">Invalid entry</div>
 </div>
 
 <div class="o-forms">
 	<label for="o-forms__textarea-disabled" class="o-forms__label">Textarea disabled</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-disabled" class="o-forms__textarea" disabled="disabled"></textarea>
+	<textarea id="o-forms__textarea-disabled" class="o-forms__textarea" disabled="disabled"></textarea>
 </div>
 
 <div class="o-forms o-forms--wide">
 	<label for="o-forms__textarea-wide" class="o-forms__label">Textarea (wide)</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-wide" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea-wide" class="o-forms__textarea"></textarea>
 </div>
 
 <div class="o-forms-section o-forms-section--highlight">
 	<div class="o-forms">
 		<label for="o-forms-section-highlight" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-section-highlight" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-section-highlight" class="o-forms__text" required />
 	</div>
 </div>
 
@@ -333,7 +333,7 @@
 	</div>
 	<div class="o-forms">
 		<label for="o-forms-message" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-message" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-message" class="o-forms__text" required />
 	</div>
 </div>
 </div>
@@ -344,7 +344,7 @@
 	</div>
 	<div class="o-forms">
 		<label for="o-forms-message-wide" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-message-wide" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-message-wide" class="o-forms__text" required />
 	</div>
 </div>
 
@@ -354,7 +354,7 @@
 	</div>
 	<div class="o-forms o-forms--error">
 		<label for="o-forms-section-error" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-section-error" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-section-error" class="o-forms__text" required />
 	</div>
 </div>
 
@@ -364,6 +364,6 @@
 	</div>
 	<div class="o-forms o-forms--error o-forms--wide">
 		<label for="o-forms-section-error-wide" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-section-error-wide" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-section-error-wide" class="o-forms__text" required />
 	</div>
 </div>

--- a/demos/src/sections.mustache
+++ b/demos/src/sections.mustache
@@ -1,7 +1,7 @@
 <div class="o-forms-section o-forms-section--highlight">
 	<div class="o-forms">
 		<label for="o-forms-section-highlight" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-section-highlight" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-section-highlight" class="o-forms__text" required />
 	</div>
 </div>
 
@@ -11,7 +11,7 @@
 	</div>
 	<div class="o-forms">
 		<label for="o-forms-message" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-message" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-message" class="o-forms__text" required />
 	</div>
 </div>
 
@@ -21,7 +21,7 @@
 	</div>
 	<div class="o-forms">
 		<label for="o-forms-message-wide" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-message-wide" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-message-wide" class="o-forms__text" required />
 	</div>
 </div>
 
@@ -31,7 +31,7 @@
 	</div>
 	<div class="o-forms o-forms--error">
 		<label for="o-forms-section-error" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-section-error" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-section-error" class="o-forms__text" required />
 		<div class="o-forms__errortext">Invalid entry</div>
 	</div>
 </div>
@@ -42,7 +42,7 @@
 	</div>
 	<div class="o-forms o-forms--error o-forms--wide">
 		<label for="o-forms-section-error-wide" class="o-forms__label">Field Label</label>
-		<input type="text" id="o-forms-section-error-wide" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="o-forms-section-error-wide" class="o-forms__text" required />
 		<div class="o-forms__errortext">Invalid entry</div>
 	</div>
 </div>

--- a/demos/src/suffix.mustache
+++ b/demos/src/suffix.mustache
@@ -1,7 +1,7 @@
 <div class="o-forms">
 	<label class="o-forms__label" for="text-suffix">Text input with suffix button</label>
 	<div class="o-forms__affix-wrapper">
-		<input id="text-suffix" type="text" placeholder="placeholder" class="o-forms__text" />
+		<input id="text-suffix" type="text" class="o-forms__text" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons o-buttons--secondary o-buttons--big">Go</button>
 		</div>
@@ -26,7 +26,7 @@
 <div class="o-forms">
 	<label class="o-forms__label" for="small-text-suffix">Small text input with suffix button</label>
 	<div class="o-forms__affix-wrapper">
-		<input id="small-text-suffix" type="text" placeholder="placeholder" class="o-forms__text o-forms__text--small" />
+		<input id="small-text-suffix" type="text" class="o-forms__text o-forms__text--small" />
 		<div class="o-forms__suffix">
 			<button type="button" class="o-buttons o-buttons--secondary">Go</button>
 		</div>

--- a/demos/src/text-inputs.mustache
+++ b/demos/src/text-inputs.mustache
@@ -1,36 +1,36 @@
 <div class="o-forms">
 	<label for="o-forms-standard" class="o-forms__label">Text input</label>
 	<div class="o-forms__additional-info">Prompt text follows the label if required..</div>
-	<input type="text" id="o-forms-standard" placeholder="placeholder" class="o-forms__text" required />
+	<input type="text" id="o-forms-standard" class="o-forms__text" required />
 </div>
 
 <div class="o-forms">
 	<label for="o-forms-optional" class="o-forms__label o-forms__label--optional">Optional text input</label>
-	<input type="text" id="o-forms-optional" placeholder="placeholder" class="o-forms__text" />
+	<input type="text" id="o-forms-optional" class="o-forms__text" />
 </div>
 
 <div class="o-forms o-forms--valid">
 	<label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
-	<input type="text" placeholder="placeholder" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
+	<input type="text" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 
 <div class="o-forms o-forms--error">
 	<label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
-	<input type="url" placeholder="placeholder" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
+	<input type="url" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
 	<div class="o-forms__errortext">Please enter a valid url</div>
 </div>
 
 <div class="o-forms">
 	<label for="o-forms-disabled" class="o-forms__label">Text input disabled</label>
-	<input type="text" placeholder="placeholder" id="o-forms-disabled" class="o-forms__text o-forms__text--valid" value="Field value" disabled="disabled" />
+	<input type="text" id="o-forms-disabled" class="o-forms__text o-forms__text--valid" value="Field value" disabled="disabled" />
 </div>
 
 <div class="o-forms o-forms--wide">
 	<label for="o-forms-full" class="o-forms__label">Text input full width</label>
-	<input type="text" placeholder="placeholder" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
+	<input type="text" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 
 <div class="o-forms">
 	<label for="o-forms-small" class="o-forms__label">Text input small</label>
-	<input type="text" id="o-forms-small" placeholder="placeholder" class="o-forms__text o-forms__text--small" />
+	<input type="text" id="o-forms-small" class="o-forms__text o-forms__text--small" />
 </div>

--- a/demos/src/textareas.mustache
+++ b/demos/src/textareas.mustache
@@ -1,26 +1,26 @@
 <div class="o-forms">
 	<label for="o-forms__textarea" class="o-forms__label">Textarea</label>
 	<div class="o-forms__additional-info">Prompt text follows the label if required.</div>
-	<textarea placeholder="Placeholder" id="o-forms__textarea" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
 </div>
 
 <div class="o-forms">
 	<label for="o-forms__textarea-optional" class="o-forms__label o-forms__label--optional">Optional textarea</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-optional" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea-optional" class="o-forms__textarea"></textarea>
 </div>
 
 <div class="o-forms o-forms--error">
 	<label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
 	<div class="o-forms__errortext">Invalid entry</div>
 </div>
 
 <div class="o-forms">
 	<label for="o-forms__textarea-disabled" class="o-forms__label">Textarea disabled</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-disabled" class="o-forms__textarea" disabled="disabled"></textarea>
+	<textarea id="o-forms__textarea-disabled" class="o-forms__textarea" disabled="disabled"></textarea>
 </div>
 
 <div class="o-forms o-forms--wide">
 	<label for="o-forms__textarea-wide" class="o-forms__label">Textarea (wide)</label>
-	<textarea placeholder="Placeholder" id="o-forms__textarea-wide" class="o-forms__textarea"></textarea>
+	<textarea id="o-forms__textarea-wide" class="o-forms__textarea"></textarea>
 </div>

--- a/demos/src/validation.mustache
+++ b/demos/src/validation.mustache
@@ -1,13 +1,13 @@
 <form action="" data-o-component="o-forms">
 	<div class="o-forms">
 		<label for="text-validation" class="o-forms__label">Text input</label>
-		<input type="text" id="text-validation" placeholder="placeholder" class="o-forms__text" required />
+		<input type="text" id="text-validation" class="o-forms__text" required />
 		<div class="o-forms__errortext">Invalid entry</div>
 	</div>
 
 	<div class="o-forms">
 		<label for="text-validation-optional" class="o-forms__label o-forms__label--optional">Another text input</label>
-		<input type="text" id="text-validation-optional" placeholder="placeholder" class="o-forms__text" />
+		<input type="text" id="text-validation-optional" class="o-forms__text" />
 	</div>
 
 	<input type="submit">

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -24,12 +24,12 @@ function htmlCode () {
 		<form data-o-component="o-forms" id="element">
 			<div class="o-forms">
 				<label for="o-forms-standard" class="o-forms__label">Text input</label>
-				<input type="text" id="required-input" placeholder="placeholder" class="o-forms__text" required pattern="valid"/>
+				<input type="text" id="required-input" class="o-forms__text" required pattern="valid"/>
 			</div>
 
 			<div class="o-forms">
 				<label for="o-forms-standard" class="o-forms__label">Text input</label>
-				<input type="email" id="standard-input" placeholder="placeholder" class="o-forms__text" />
+				<input type="email" id="standard-input" class="o-forms__text" />
 			</div>
 
 			<input type="submit">
@@ -42,8 +42,8 @@ function htmlCode () {
 function allInputsHtmlCode () {
 	const html = `<div>
 		<form data-o-component="o-forms" id="element">
-			<input type="text" id="required-input" placeholder="placeholder" class="o-forms__text" required />
-			<input type="email" id="standard-input" placeholder="placeholder" class="o-forms__text" />
+			<input type="text" id="required-input" class="o-forms__text" required />
+			<input type="email" id="standard-input" class="o-forms__text" />
 			<select class="o-forms__select">
 				<option>test</option>
 			</select>


### PR DESCRIPTION
Request by @draysonandstock. Placeholders may cause confusion, especially in pre-filled form contexts. We would rather keep hints outside the input as addition info. 

https://financialtimes.slack.com/archives/C2LMEKC6S/p1518602515000541
https://financialtimes.slack.com/files/U58PJHY78/F987TTRPS/screen_shot_2018-02-14_at_10.12.34.png