### PR TITLE
Correct padding on small select inputs.

### DIFF
--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -176,6 +176,10 @@
 	.#{$class}__select--small {
 		@include oFormsCommonSmall;
 	}
+
+	.#{$class}__select--small {
+		@include oFormsSelectSmall();
+	}
 }
 
 /// @access public

--- a/src/scss/mixins/_select.scss
+++ b/src/scss/mixins/_select.scss
@@ -54,6 +54,16 @@
 
 /// @access public
 /// @require {mixin} oFormsCommonField
+/// @require {mixin} oFormsCommonSmall
+/// @output Styles to support a small select input.
+@mixin oFormsSelectSmall {
+	padding-right: $_o-forms-select-small-iconsize + $_o-forms-field-default-padding-leftright;
+	// In old IE, since we can't hide the stock browser arrow.
+	padding-right: #{$_o-forms-field-default-padding-leftright}\9;
+}
+
+/// @access public
+/// @require {mixin} oFormsCommonField
 /// @require {mixin} oFormsSelect
 /// @output Styles for a multi select input.
 @mixin oFormsSelectMulti() {


### PR DESCRIPTION
Right padding for the icon on small select boxes is too large:
<img width="158" alt="screen shot 2018-03-14 at 10 44 20" src="https://user-images.githubusercontent.com/10405691/37397906-baf59750-2774-11e8-8923-d8719f59bdb2.png">

Any client using `oFormsCommonSmall` directly (i.e. the registry) will now also need to include `oFormsSelectSmall` to correct this. For a small tweak manual intervention feels like a failing, however I felt it was more appropriate than adding a `select` selector within `oFormsCommonSmall` -- given `oFormsCommonSmall` has not been widely used yet anyway.