### PR TITLE
Do not show validation styles if input is disabled.

### DIFF
--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -69,18 +69,21 @@
 /// @access public
 /// @output Shared invalid state styles.
 @mixin oFormsCommonFieldInvalid {
-	@include oColorsFor(o-forms-field-invalid);
-
-	&:focus {
-		box-shadow: 0 0 0 2px oColorsGetColorFor(o-forms-field-invalid, border);
+	&:not(:disabled) {
+		@include oColorsFor(o-forms-field-invalid);
+		&:focus {
+			box-shadow: 0 0 0 2px oColorsGetColorFor(o-forms-field-invalid, border);
+		}
 	}
 }
 
 /// @access public
 /// @output Shared valid state styles.
 @mixin oFormsCommonFieldValid {
-	@include oColorsFor(o-forms-field-valid);
-	background-color: rgba(oColorsGetColorFor(o-forms-field-valid, background), 0.05);
+	&:not(:disabled) {
+		@include oColorsFor(o-forms-field-valid);
+		background-color: rgba(oColorsGetColorFor(o-forms-field-valid, background), 0.05);
+	}
 }
 
 /// @access public


### PR DESCRIPTION
Fields will only show as valid/invalid if they are not disabled.

Disabled fields with validator classes:
<img width="455" alt="screen shot 2018-03-23 at 15 20 25" src="https://user-images.githubusercontent.com/10405691/37838380-a42b8920-2eaf-11e8-90cc-7e183639064c.png">
