### PR TITLE
Inline forms and other visual improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ Inline forms offer more options. For full demo markup see [inline examples](http
 
 It is possible to add additional information to form fields with `.o-forms__additional-info`. Additonal information is not limited to a text input, it could also apply against a `select`, `textarea`, `checkbox`, etc.
 
+Note that the label has an `aria-describedby` attribute which matches the `id` of the additional information. This enables screen readers to automatically read the additonal information after reading the form label.
+
 ```html
 <div class="o-forms">
-	<label for="o-forms-demo-additional" class="o-forms__label">Text input example</label>
-	<div class="o-forms__additional-info">Additional info follows the label if required.</div>
-	<input type="text" id="o-forms-demo-additional" class="o-forms__text" required />
+	<label aria-describedby="demo-additional-info" for="demo-text-input" class="o-forms__label">Text input example</label>
+	<div id="demo-additional-info" class="o-forms__additional-info">Additional info follows the label if required.</div>
+	<input type="text" id="demo-text-input" class="o-forms__text" required />
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,42 +29,6 @@ Each form field is made up of at least 3 elements:
 </div>
 ```
 
-#### Inline forms
-
-By default `o-forms` is stacked but form fields may also be displayed inline by adding a modifier `o-forms--inline`.
-
-```html
-<div class="o-forms o-forms--inline">
-	<label for="o-forms-demo-text" class="o-forms__label">Text input example</label>
-	<input type="text" id="o-forms-demo-text" class="o-forms__text" required />
-</div>
-```
-
-Inline forms must wrap multiple messaging elements, such as a label and additional information, using `o-forms__inline-item`.
-
-```html
-<div class="o-forms o-forms--inline">
-    <div class="o-forms__inline-item">
-	    <label for="o-forms__textarea" class="o-forms__label">Label</label>
-	    <div class="o-forms__additional-info">Additional information</div>
-    </div>
-	<!-- input markup -->
-</div>
-```
-
-If `o-forms` is used on a `fieldset` a wrapper `o-forms__inline-container` must also be addded.
-
-```html
-<fieldset class="o-forms o-forms--inline">
-    <div class="o-forms__inline-container">
-        <legend class="o-forms__label">Legend</legend>
-        <!-- radio button markup -->
-    </div>
-</fieldset>
-```
-
-Inline forms offer more options. For full demo markup see [inline examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/inline) on the Origami Registry.
-
 #### Additonal field information
 
 It is possible to add additional information to form fields with `.o-forms__additional-info`. Additonal information is not limited to a text input, it could also apply against a `select`, `textarea`, `checkbox`, etc.
@@ -98,7 +62,6 @@ The class `.o-forms--wide` can be used to show form fields without width restric
 	<input type="text" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 ```
-
 
 #### Text inputs
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,42 @@ Each form field is made up of at least 3 elements:
 </div>
 ```
 
+#### Inline forms
+
+By default `o-forms` is stacked but form fields may also be displayed inline by adding a modifier `o-forms--inline`.
+
+```html
+<div class="o-forms o-forms--inline">
+	<label for="o-forms-demo-text" class="o-forms__label">Text input example</label>
+	<input type="text" id="o-forms-demo-text" class="o-forms__text" required />
+</div>
+```
+
+Inline forms must wrap multiple messaging elements, such as a label and additional information, using `o-forms__inline-item`.
+
+```html
+<div class="o-forms o-forms--inline">
+    <div class="o-forms__inline-item">
+	    <label for="o-forms__textarea" class="o-forms__label">Label</label>
+	    <div class="o-forms__additional-info">Additional information</div>
+    </div>
+	<!-- input markup -->
+</div>
+```
+
+If `o-forms` is used on a `fieldset` a wrapper `o-forms__inline-container` must also be addded.
+
+```html
+<fieldset class="o-forms o-forms--inline">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">Legend</legend>
+        <!-- radio button markup -->
+    </div>
+</fieldset>
+```
+
+Inline forms offer more options. For full demo markup see [inline examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/inline) on the Origami Registry.
+
 #### Additonal field information
 
 It is possible to add additional information to form fields with `.o-forms__additional-info`. Additonal information is not limited to a text input, it could also apply against a `select`, `textarea`, `checkbox`, etc.
@@ -62,6 +98,7 @@ The class `.o-forms--wide` can be used to show form fields without width restric
 	<input type="text" id="o-forms-full" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 ```
+
 
 #### Text inputs
 

--- a/demos/src/checkboxes.mustache
+++ b/demos/src/checkboxes.mustache
@@ -1,6 +1,6 @@
 <div class="o-forms">
-	<legend class="o-forms__label">Default checkboxes</legend>
-	<div class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
+	<legend aria-describedby="default-checkboxes-info" class="o-forms__label">Default checkboxes</legend>
+	<div id="default-checkboxes-info" class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
 	<div class="o-forms__group">
 		<input type="checkbox" name="checkbox" value="1" class="o-forms__checkbox" id="checkbox11" checked="checked" />
 		<label for="checkbox11" class="o-forms__label">Checkbox 1</label>
@@ -24,8 +24,8 @@
 </fieldset>
 
 <div class="o-forms">
-	<label for="form-secret" class="o-forms__label">Right side control checkbox</label>
-	<div class="o-forms__additional-info">Interface demo only, password hide/show functionality is not currently included in o-forms.</div>
+	<label aria-describedby="right-checkboxes-info" for="form-secret" class="o-forms__label">Right side control checkbox</label>
+	<div id="right-checkboxes-info" class="o-forms__additional-info">Interface demo only, password hide/show functionality is not currently included in o-forms.</div>
 	<input type="password" id="form-secret" class="o-forms__text" required />
 	<div class="o-forms__group o-forms__group--inline">
 		<input type="checkbox" name="checkbox" value="2" class="o-forms__checkbox o-forms__checkbox--right" id="controlCheckbox" />

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -12,7 +12,8 @@ body {
 }
 
 .inverse-demo {
-	margin: 8px -#{oGridGutter()};
-	padding: 0 oGridGutter();
+	margin-left: -#{oGridGutter()};
+	margin-right: -#{oGridGutter()};
+	padding: oGridGutter();
 	background-color: oColorsGetPaletteColor('slate');
 }

--- a/demos/src/inline.mustache
+++ b/demos/src/inline.mustache
@@ -149,7 +149,7 @@
     <div class="o-forms__errortext">Please enter a valid url</div>
 </div>
 
-<div class="o-forms o-forms--inline o-forms--textarea">
+<div class="o-forms o-forms--inline">
     <div class="o-forms__inline-item">
 	    <label for="o-forms__textarea" class="o-forms__label">Textarea</label>
 	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
@@ -157,7 +157,7 @@
 	<textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
 </div>
 
-<div class="o-forms o-forms--inline o-forms--textarea o-forms--error">
+<div class="o-forms o-forms--inline o-forms--error">
 	<label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
 	<textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
     <div class="o-forms__errortext">Invalid entry</div>

--- a/demos/src/inline.mustache
+++ b/demos/src/inline.mustache
@@ -1,118 +1,94 @@
 <fieldset class="o-forms o-forms--inline">
     <div class="o-forms__inline-container">
-        <div class="o-forms__inline-item">
-            <legend class="o-forms__label">No default selection</legend>
+        <legend class="o-forms__label">No default selection</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="radio4" value="daily" class="o-forms__radio-button" id="radio41" />
+            <label for="radio41" class="o-forms__label">Daily</label>
+            <input type="radio" name="radio4" value="weekly" class="o-forms__radio-button" id="radio42" />
+            <label for="radio42" class="o-forms__label">Weekly</label>
         </div>
-        <div class="o-forms__inline-item">
-            <div class="o-forms__group o-forms__group--inline-together">
-                <input type="radio" name="radio4" value="daily" class="o-forms__radio-button" id="radio41" />
-                <label for="radio41" class="o-forms__label">Daily</label>
-                <input type="radio" name="radio4" value="weekly" class="o-forms__radio-button" id="radio42" />
-                <label for="radio42" class="o-forms__label">Weekly</label>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">Positive / negative choice with a default selection</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="radio8" value="yes" class="o-forms__radio-button" id="radio81" />
+            <label for="radio81" class="o-forms__label">Yes</label>
+            <input type="radio" name="radio8" value="no" class="o-forms__radio-button o-forms__radio-button--negative" id="radio82" checked />
+            <label for="radio82" class="o-forms__label">No</label>
+        </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline o-forms--checkboxes">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">Checkbox Toggle</legend>
+        <div class="o-forms__group">
+            <div class="o-forms__toggle">
+                <input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle1" />
+                <label for="checkboxToggle1" class="o-forms__label">Checkbox Toggle 1</label>
             </div>
-        </div>
-</fieldset>
-
-<fieldset class="o-forms o-forms--inline">
-    <div class="o-forms__inline-container">
-	    <div class="o-forms__inline-item">
-            <legend class="o-forms__label">Positive / negative choice with a default selection</legend>
-        </div>
-        <div class="o-forms__inline-item">
-	        <div class="o-forms__group o-forms__group--inline-together">
-    		    <input type="radio" name="radio8" value="yes" class="o-forms__radio-button" id="radio81" />
-    		    <label for="radio81" class="o-forms__label">Yes</label>
-    		    <input type="radio" name="radio8" value="no" class="o-forms__radio-button o-forms__radio-button--negative" id="radio82" checked />
-    		    <label for="radio82" class="o-forms__label">No</label>
-	        </div>
-	    </div>
-</fieldset>
-
-<fieldset class="o-forms o-forms--inline">
-    <div class="o-forms__inline-container">
-        <div class="o-forms__inline-item">
-            <legend class="o-forms__label">Checkbox Toggle</legend>
-        </div>
-        <div class="o-forms__inline-item">
-            <div class="o-forms__group">
-                <div class="o-forms__toggle">
-                    <input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle1" />
-                    <label for="checkboxToggle1" class="o-forms__label">Checkbox Toggle 1</label>
-                </div>
-                <div class="o-forms__toggle">
-                    <input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle2" checked="checked" />
-                    <label for="checkboxToggle2" class="o-forms__label">Checkbox Toggle 2</label>
-                </div>
+            <div class="o-forms__toggle">
+                <input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle2" checked="checked" />
+                <label for="checkboxToggle2" class="o-forms__label">Checkbox Toggle 2</label>
             </div>
         </div>
     </div>
 </fieldset>
 
-<div class="o-forms o-forms--inline">
+<div class="o-forms o-forms--inline o-forms--checkboxes">
     <div class="o-forms__inline-item">
         <legend class="o-forms__label">Default checkboxes</legend>
         <div class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
     </div>
-    <div class="o-forms__inline-item">
-        <div class="o-forms__group">
-            <input type="checkbox" name="checkbox" value="1" class="o-forms__checkbox" id="checkbox11" checked="checked" />
-            <label for="checkbox11" class="o-forms__label">Checkbox 1</label>
-            <input type="checkbox" name="checkbox" value="2" class="o-forms__checkbox" id="checkbox12" />
-            <label for="checkbox12" class="o-forms__label">Checkbox 2</label>
-            <input type="checkbox" name="checkbox" value="3" class="o-forms__checkbox" id="checkbox13" />
-            <label for="checkbox13" class="o-forms__label">Checkbox 3</label>
-        </div>
+    <div class="o-forms__group">
+        <input type="checkbox" name="checkbox" value="1" class="o-forms__checkbox" id="checkbox11" checked="checked" />
+        <label for="checkbox11" class="o-forms__label">Checkbox 1</label>
+        <input type="checkbox" name="checkbox" value="2" class="o-forms__checkbox" id="checkbox12" />
+        <label for="checkbox12" class="o-forms__label">Checkbox 2</label>
+        <input type="checkbox" name="checkbox" value="3" class="o-forms__checkbox" id="checkbox13" />
+        <label for="checkbox13" class="o-forms__label">Checkbox 3</label>
     </div>
 </div>
 
-<fieldset class="o-forms o-forms--inline o-forms--error">
+<fieldset class="o-forms o-forms--inline o-forms--radios o-forms--error">
     <div class="o-forms__inline-container">
-        <div class="o-forms__inline-item">
-            <legend class="o-forms__label">Error</legend>
+        <legend class="o-forms__label">Error</legend>
+        <div class="o-forms__group">
+            <input type="checkbox" name="checkbox3" value="1" class="o-forms__checkbox" id="checkbox31" checked="checked" />
+            <label for="checkbox31" class="o-forms__label">Checkbox 1</label>
+            <input type="checkbox" name="checkbox3" value="2" class="o-forms__checkbox" id="checkbox32" />
+            <label for="checkbox32" class="o-forms__label">Checkbox 2</label>
         </div>
-        <div class="o-forms__inline-item">
-            <div class="o-forms__group">
-                <input type="checkbox" name="checkbox3" value="1" class="o-forms__checkbox" id="checkbox31" checked="checked" />
-                <label for="checkbox31" class="o-forms__label">Checkbox 1</label>
-                <input type="checkbox" name="checkbox3" value="2" class="o-forms__checkbox" id="checkbox32" />
-                <label for="checkbox32" class="o-forms__label">Checkbox 2</label>
-            </div>
-            <div class="o-forms__errortext">Invalid entry</div>
-        </div>
+        <div class="o-forms__errortext">Invalid entry</div>
     </div>
 </fieldset>
 
-<fieldset class="o-forms o-forms--inline">
+<fieldset class="o-forms o-forms--inline o-forms--radios">
     <div class="o-forms__inline-container">
         <div class="o-forms__inline-item">
             <legend class="o-forms__label">Default radio controls</legend>
             <div class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
         </div>
-        <div class="o-forms__inline-item">
-            <div class="o-forms__group">
-                <input type="radio" name="radio" value="1" class="o-forms__radio" id="radio11" checked="checked" />
-                <label for="radio11" class="o-forms__label">Radio 1</label>
-                <input type="radio" name="radio" value="2" class="o-forms__radio" id="radio12" />
-                <label for="radio12" class="o-forms__label">Radio 2</label>
-            </div>
+        <div class="o-forms__group">
+            <input type="radio" name="radio" value="1" class="o-forms__radio" id="radio11" checked="checked" />
+            <label for="radio11" class="o-forms__label">Radio 1</label>
+            <input type="radio" name="radio" value="2" class="o-forms__radio" id="radio12" />
+            <label for="radio12" class="o-forms__label">Radio 2</label>
         </div>
     </div>
 </fieldset>
 
-<fieldset class="o-forms o-forms--inline o-forms--error">
+<fieldset class="o-forms o-forms--inline o-forms--radios o-forms--error">
     <div class="o-forms__inline-container">
-        <div class="o-forms__inline-item">
-            <legend class="o-forms__label">Error</legend>
+        <legend class="o-forms__label">Error</legend>
+        <div class="o-forms__group">
+            <input type="radio" name="radio3" value="1" class="o-forms__radio" id="radio31" checked="checked" />
+            <label for="radio31" class="o-forms__label">Radio 1</label>
+            <input type="radio" name="radio3" value="2" class="o-forms__radio" id="radio32" />
+            <label for="radio32" class="o-forms__label">Radio 2</label>
         </div>
-        <div class="o-forms__inline-item">
-            <div class="o-forms__group">
-                <input type="radio" name="radio3" value="1" class="o-forms__radio" id="radio31" checked="checked" />
-                <label for="radio31" class="o-forms__label">Radio 1</label>
-                <input type="radio" name="radio3" value="2" class="o-forms__radio" id="radio32" />
-                <label for="radio32" class="o-forms__label">Radio 2</label>
-            </div>
-            <div class="o-forms__errortext">Invalid entry</div>
-        </div>
+        <div class="o-forms__errortext">Invalid entry</div>
     </div>
 </fieldset>
 
@@ -130,18 +106,17 @@
 </div>
 
 <div class="o-forms o-forms--inline o-forms--error">
-    <div class="o-forms__inline-item">
-	    <label for="select-invalid" class="o-forms__label">Select box (error)</label>
-    </div>
-    <div class="o-forms__inline-item">
-        <select id="select-invalid" class="o-forms__select">
-            <option value="option1" selected>Option 1</option>
-            <option value="option2">Option 2</option>
-            <option value="option3">Option 3</option>
-            <option value="option4">Option 4</option>
-        </select>
-        <div class="o-forms__errortext">Invalid entry</div>
-    </div>
+	<label for="select-invalid" class="o-forms__label">Select box (error)</label>
+    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+    <select id="select-invalid" class="o-forms__select">
+        <option value="option1" selected>Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+        <option value="option4">Option 4</option>
+    </select>
+    <div class="o-forms__errortext">Invalid entry</div>
 </div>
 
 <div class="o-forms o-forms--inline">
@@ -149,56 +124,36 @@
 	    <label for="o-forms-standard" class="o-forms__label">Text input</label>
 	    <div class="o-forms__additional-info">Prompt text follows the label if required..</div>
     </div>
-    <div class="o-forms__inline-item">
-	    <input type="text" id="o-forms-standard" class="o-forms__text" required />
-    </div>
+	<input type="text" id="o-forms-standard" class="o-forms__text" required />
 </div>
 
 <div class="o-forms o-forms--inline">
-    <div class="o-forms__inline-item">
-	    <label for="o-forms-optional" class="o-forms__label o-forms__label--optional">Optional text input</label>
-    </div>
-    <div class="o-forms__inline-item">
-	    <input type="text" id="o-forms-optional" class="o-forms__text" />
-    </div>
+	<label for="o-forms-optional" class="o-forms__label o-forms__label--optional">Optional text input</label>
+	<input type="text" id="o-forms-optional" class="o-forms__text" />
 </div>
 
 <div class="o-forms o-forms--inline o-forms--valid">
-    <div class="o-forms__inline-item">
-	    <label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
-    </div>
-    <div class="o-forms__inline-item">
-	    <input type="text" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
-    </div>
+	<label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
+	<input type="text" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
 </div>
 
 <div class="o-forms o-forms--inline o-forms--error">
-    <div class="o-forms__inline-item">
-	    <label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
-    </div>
-    <div class="o-forms__inline-item">
-        <input type="url" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
-        <div class="o-forms__errortext">Please enter a valid url</div>
-    </div>
+	<label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
+    <input type="url" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
+    <div class="o-forms__errortext">Please enter a valid url</div>
 </div>
 
-<div class="o-forms o-forms--inline">
+<div class="o-forms o-forms--inline o-forms--align-start">
     <div class="o-forms__inline-item">
 	    <label for="o-forms__textarea" class="o-forms__label">Textarea</label>
 	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
     </div>
-    <div class="o-forms__inline-item">
-	    <textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
-    </div>
+	<textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
 </div>
 
 <div class="o-forms o-forms--inline o-forms--error">
-    <div class="o-forms__inline-item">
-	    <label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
-    </div>
-    <div class="o-forms__inline-item">
-	    <textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
-        <div class="o-forms__errortext">Invalid entry</div>
-    </div>
+	<label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
+	<textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
+    <div class="o-forms__errortext">Invalid entry</div>
 </div>
 

--- a/demos/src/inline.mustache
+++ b/demos/src/inline.mustache
@@ -40,8 +40,8 @@
 
 <div class="o-forms o-forms--inline o-forms--checkboxes">
     <div class="o-forms__inline-item">
-        <legend class="o-forms__label">Default checkboxes</legend>
-        <div class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
+        <legend aria-describedby="default-checkboxes-info" class="o-forms__label">Default checkboxes</legend>
+        <div id="default-checkboxes-info" class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
     </div>
     <div class="o-forms__group">
         <input type="checkbox" name="checkbox" value="1" class="o-forms__checkbox" id="checkbox11" checked="checked" />
@@ -69,8 +69,8 @@
 <fieldset class="o-forms o-forms--inline o-forms--radios">
     <div class="o-forms__inline-container">
         <div class="o-forms__inline-item">
-            <legend class="o-forms__label">Default radio controls</legend>
-            <div class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
+            <legend aria-describedby="default-radio-controls" class="o-forms__label">Default radio controls</legend>
+            <div id="default-radio-controls" class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
         </div>
         <div class="o-forms__group">
             <input type="radio" name="radio" value="1" class="o-forms__radio" id="radio11" checked="checked" />
@@ -96,8 +96,8 @@
 
 <div class="o-forms o-forms--inline">
     <div class="o-forms__inline-item">
-	    <label for="select-standard" class="o-forms__label">Select box</label>
-	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+	    <label aria-describedby="select-box-info" for="select-standard" class="o-forms__label">Select box</label>
+	    <div id="select-box-info" class="o-forms__additional-info">Prompt text follows the label if required.</div>
     </div>
 	<select id="select-standard" class="o-forms__select">
 		<option value="option1" selected>Option 1</option>
@@ -120,8 +120,8 @@
 
 <div class="o-forms o-forms--inline">
     <div class="o-forms__inline-item">
-	    <label for="o-forms-standard" class="o-forms__label">Text input</label>
-	    <div class="o-forms__additional-info">Prompt text follows the label if required..</div>
+	    <label aria-describedby="text-input-info" for="o-forms-standard" class="o-forms__label">Text input</label>
+	    <div id="text-input-info" class="o-forms__additional-info">Prompt text follows the label if required..</div>
     </div>
 	<input type="text" id="o-forms-standard" class="o-forms__text" required />
 </div>
@@ -134,16 +134,16 @@
 
 <div class="o-forms o-forms--inline">
     <div class="o-forms__inline-item o-forms__inline-item--long">
-	    <label for="o-forms-long" class="o-forms__label">A long label and additional content</label>
-	    <div class="o-forms__additional-info">Inline inputs with long labels / additonal content have a unique class to align them to the start and span error messages.</div>
+	    <label aria-describedby="long-label-content-info" for="o-forms-long" class="o-forms__label">A long label and additional content</label>
+	    <div id="long-label-content-info" class="o-forms__additional-info">Inline inputs with long labels / additonal content have a unique class to align them to the start and span error messages.</div>
     </div>
 	<input type="text" id="o-forms-long" class="o-forms__text" required />
 </div>
 
 <div class="o-forms o-forms--inline o-forms--error">
     <div class="o-forms__inline-item o-forms__inline-item--long">
-	    <label for="o-forms-invalid-long" class="o-forms__label">A long label and additional content</label>
-	    <div class="o-forms__additional-info">Inline inputs with long labels / additonal content have a unique class to align them to the start and span error messages.</div>
+	    <label aria-describedby="long-label-content-invalid-info" for="o-forms-invalid-long" class="o-forms__label">A long label and additional content</label>
+	    <div id="long-label-content-invalid-info" class="o-forms__additional-info">Inline inputs with long labels / additonal content have a unique class to align them to the start and span error messages.</div>
     </div>
     <input type="url" id="o-forms-invalid-long" class="o-forms__text" value="hp://invalid.com" />
     <div class="o-forms__errortext">Please enter a valid url</div>
@@ -151,8 +151,8 @@
 
 <div class="o-forms o-forms--inline">
     <div class="o-forms__inline-item">
-	    <label for="o-forms__textarea" class="o-forms__label">Textarea</label>
-	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+	    <label aria-describedby="textarea-info" for="o-forms__textarea" class="o-forms__label">Textarea</label>
+	    <div id="textarea-info" class="o-forms__additional-info">Prompt text follows the label if required.</div>
     </div>
 	<textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
 </div>

--- a/demos/src/inline.mustache
+++ b/demos/src/inline.mustache
@@ -97,7 +97,7 @@
 	    <label for="select-standard" class="o-forms__label">Select box</label>
 	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
     </div>
-	<select id="select-standard" class="o-forms__select o-forms__inline-item">
+	<select id="select-standard" class="o-forms__select">
 		<option value="option1" selected>Option 1</option>
 		<option value="option2">Option 2</option>
 		<option value="option3">Option 3</option>
@@ -107,9 +107,6 @@
 
 <div class="o-forms o-forms--inline o-forms--error">
 	<label for="select-invalid" class="o-forms__label">Select box (error)</label>
-    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
-    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
-    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
     <select id="select-invalid" class="o-forms__select">
         <option value="option1" selected>Option 1</option>
         <option value="option2">Option 2</option>
@@ -127,23 +124,30 @@
 	<input type="text" id="o-forms-standard" class="o-forms__text" required />
 </div>
 
-<div class="o-forms o-forms--inline">
-	<label for="o-forms-optional" class="o-forms__label o-forms__label--optional">Optional text input</label>
-	<input type="text" id="o-forms-optional" class="o-forms__text" />
-</div>
-
-<div class="o-forms o-forms--inline o-forms--valid">
-	<label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
-	<input type="text" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
-</div>
-
 <div class="o-forms o-forms--inline o-forms--error">
 	<label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
     <input type="url" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
     <div class="o-forms__errortext">Please enter a valid url</div>
 </div>
 
-<div class="o-forms o-forms--inline o-forms--align-start">
+<div class="o-forms o-forms--inline">
+    <div class="o-forms__inline-item o-forms__inline-item--long">
+	    <label for="o-forms-long" class="o-forms__label">A long label and additional content</label>
+	    <div class="o-forms__additional-info">Inline inputs with long labels / additonal content have a unique class to align them to the start and span error messages.</div>
+    </div>
+	<input type="text" id="o-forms-long" class="o-forms__text" required />
+</div>
+
+<div class="o-forms o-forms--inline o-forms--error">
+    <div class="o-forms__inline-item o-forms__inline-item--long">
+	    <label for="o-forms-invalid-long" class="o-forms__label">A long label and additional content</label>
+	    <div class="o-forms__additional-info">Inline inputs with long labels / additonal content have a unique class to align them to the start and span error messages.</div>
+    </div>
+    <input type="url" id="o-forms-invalid-long" class="o-forms__text" value="hp://invalid.com" />
+    <div class="o-forms__errortext">Please enter a valid url</div>
+</div>
+
+<div class="o-forms o-forms--inline o-forms--textarea">
     <div class="o-forms__inline-item">
 	    <label for="o-forms__textarea" class="o-forms__label">Textarea</label>
 	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
@@ -151,7 +155,7 @@
 	<textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
 </div>
 
-<div class="o-forms o-forms--inline o-forms--error">
+<div class="o-forms o-forms--inline o-forms--textarea o-forms--error">
 	<label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
 	<textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
     <div class="o-forms__errortext">Invalid entry</div>

--- a/demos/src/inline.mustache
+++ b/demos/src/inline.mustache
@@ -7,6 +7,7 @@
             <input type="radio" name="radio4" value="weekly" class="o-forms__radio-button" id="radio42" />
             <label for="radio42" class="o-forms__label">Weekly</label>
         </div>
+    </div>
 </fieldset>
 
 <fieldset class="o-forms o-forms--inline">
@@ -18,6 +19,7 @@
             <input type="radio" name="radio8" value="no" class="o-forms__radio-button o-forms__radio-button--negative" id="radio82" checked />
             <label for="radio82" class="o-forms__label">No</label>
         </div>
+    </div>
 </fieldset>
 
 <fieldset class="o-forms o-forms--inline o-forms--checkboxes">

--- a/demos/src/inline.mustache
+++ b/demos/src/inline.mustache
@@ -1,0 +1,204 @@
+<fieldset class="o-forms o-forms--inline">
+    <div class="o-forms__inline-container">
+        <div class="o-forms__inline-item">
+            <legend class="o-forms__label">No default selection</legend>
+        </div>
+        <div class="o-forms__inline-item">
+            <div class="o-forms__group o-forms__group--inline-together">
+                <input type="radio" name="radio4" value="daily" class="o-forms__radio-button" id="radio41" />
+                <label for="radio41" class="o-forms__label">Daily</label>
+                <input type="radio" name="radio4" value="weekly" class="o-forms__radio-button" id="radio42" />
+                <label for="radio42" class="o-forms__label">Weekly</label>
+            </div>
+        </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline">
+    <div class="o-forms__inline-container">
+	    <div class="o-forms__inline-item">
+            <legend class="o-forms__label">Positive / negative choice with a default selection</legend>
+        </div>
+        <div class="o-forms__inline-item">
+	        <div class="o-forms__group o-forms__group--inline-together">
+    		    <input type="radio" name="radio8" value="yes" class="o-forms__radio-button" id="radio81" />
+    		    <label for="radio81" class="o-forms__label">Yes</label>
+    		    <input type="radio" name="radio8" value="no" class="o-forms__radio-button o-forms__radio-button--negative" id="radio82" checked />
+    		    <label for="radio82" class="o-forms__label">No</label>
+	        </div>
+	    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline">
+    <div class="o-forms__inline-container">
+        <div class="o-forms__inline-item">
+            <legend class="o-forms__label">Checkbox Toggle</legend>
+        </div>
+        <div class="o-forms__inline-item">
+            <div class="o-forms__group">
+                <div class="o-forms__toggle">
+                    <input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle1" />
+                    <label for="checkboxToggle1" class="o-forms__label">Checkbox Toggle 1</label>
+                </div>
+                <div class="o-forms__toggle">
+                    <input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle2" checked="checked" />
+                    <label for="checkboxToggle2" class="o-forms__label">Checkbox Toggle 2</label>
+                </div>
+            </div>
+        </div>
+    </div>
+</fieldset>
+
+<div class="o-forms o-forms--inline">
+    <div class="o-forms__inline-item">
+        <legend class="o-forms__label">Default checkboxes</legend>
+        <div class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
+    </div>
+    <div class="o-forms__inline-item">
+        <div class="o-forms__group">
+            <input type="checkbox" name="checkbox" value="1" class="o-forms__checkbox" id="checkbox11" checked="checked" />
+            <label for="checkbox11" class="o-forms__label">Checkbox 1</label>
+            <input type="checkbox" name="checkbox" value="2" class="o-forms__checkbox" id="checkbox12" />
+            <label for="checkbox12" class="o-forms__label">Checkbox 2</label>
+            <input type="checkbox" name="checkbox" value="3" class="o-forms__checkbox" id="checkbox13" />
+            <label for="checkbox13" class="o-forms__label">Checkbox 3</label>
+        </div>
+    </div>
+</div>
+
+<fieldset class="o-forms o-forms--inline o-forms--error">
+    <div class="o-forms__inline-container">
+        <div class="o-forms__inline-item">
+            <legend class="o-forms__label">Error</legend>
+            <div class="o-forms__errortext">Invalid entry</div>
+        </div>
+        <div class="o-forms__inline-item">
+            <div class="o-forms__group">
+                <input type="checkbox" name="checkbox3" value="1" class="o-forms__checkbox" id="checkbox31" checked="checked" />
+                <label for="checkbox31" class="o-forms__label">Checkbox 1</label>
+                <input type="checkbox" name="checkbox3" value="2" class="o-forms__checkbox" id="checkbox32" />
+                <label for="checkbox32" class="o-forms__label">Checkbox 2</label>
+            </div>
+        </div>
+    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline">
+    <div class="o-forms__inline-container">
+        <div class="o-forms__inline-item">
+            <legend class="o-forms__label">Default radio controls</legend>
+            <div class="o-forms__additional-info">Prompt text follows the ledgend if required.</div>
+        </div>
+        <div class="o-forms__inline-item">
+            <div class="o-forms__group">
+                <input type="radio" name="radio" value="1" class="o-forms__radio" id="radio11" checked="checked" />
+                <label for="radio11" class="o-forms__label">Radio 1</label>
+                <input type="radio" name="radio" value="2" class="o-forms__radio" id="radio12" />
+                <label for="radio12" class="o-forms__label">Radio 2</label>
+            </div>
+        </div>
+    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline o-forms--error">
+    <div class="o-forms__inline-container">
+        <div class="o-forms__inline-item">
+            <legend class="o-forms__label">Error</legend>
+            <div class="o-forms__errortext">Invalid entry</div>
+        </div>
+        <div class="o-forms__inline-item">
+            <div class="o-forms__group">
+                <input type="radio" name="radio3" value="1" class="o-forms__radio" id="radio31" checked="checked" />
+                <label for="radio31" class="o-forms__label">Radio 1</label>
+                <input type="radio" name="radio3" value="2" class="o-forms__radio" id="radio32" />
+                <label for="radio32" class="o-forms__label">Radio 2</label>
+            </div>
+        </div>
+    </div>
+</fieldset>
+
+<div class="o-forms o-forms--inline">
+    <div class="o-forms__inline-item">
+	    <label for="select-standard" class="o-forms__label">Select box</label>
+	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+    </div>
+	<select id="select-standard" class="o-forms__select o-forms__inline-item">
+		<option value="option1" selected>Option 1</option>
+		<option value="option2">Option 2</option>
+		<option value="option3">Option 3</option>
+		<option value="option4">Option 4</option>
+	</select>
+</div>
+
+<div class="o-forms o-forms--inline o-forms--error">
+    <div class="o-forms__inline-item">
+	    <label for="select-invalid" class="o-forms__label">Select box (error)</label>
+	    <div class="o-forms__errortext">Invalid entry</div>
+    </div>
+    <div class="o-forms__inline-item">
+        <select id="select-invalid" class="o-forms__select">
+            <option value="option1" selected>Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>
+
+<div class="o-forms o-forms--inline">
+    <div class="o-forms__inline-item">
+	    <label for="o-forms-standard" class="o-forms__label">Text input</label>
+	    <div class="o-forms__additional-info">Prompt text follows the label if required..</div>
+    </div>
+    <div class="o-forms__inline-item">
+	    <input type="text" id="o-forms-standard" class="o-forms__text" required />
+    </div>
+</div>
+
+<div class="o-forms o-forms--inline">
+    <div class="o-forms__inline-item">
+	    <label for="o-forms-optional" class="o-forms__label o-forms__label--optional">Optional text input</label>
+    </div>
+    <div class="o-forms__inline-item">
+	    <input type="text" id="o-forms-optional" class="o-forms__text" />
+    </div>
+</div>
+
+<div class="o-forms o-forms--inline o-forms--valid">
+    <div class="o-forms__inline-item">
+	    <label for="o-forms-valid" class="o-forms__label">Text input with valid entry</label>
+    </div>
+    <div class="o-forms__inline-item">
+	    <input type="text" id="o-forms-valid" class="o-forms__text o-forms__text--valid" value="Field value" />
+    </div>
+</div>
+
+<div class="o-forms o-forms--inline o-forms--error">
+    <div class="o-forms__inline-item">
+	    <label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
+        <div class="o-forms__errortext">Please enter a valid url</div>
+    </div>
+    <div class="o-forms__inline-item">
+        <input type="url" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
+    </div>
+</div>
+
+<div class="o-forms o-forms--inline">
+    <div class="o-forms__inline-item">
+	    <label for="o-forms__textarea" class="o-forms__label">Textarea</label>
+	    <div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+    </div>
+    <div class="o-forms__inline-item">
+	    <textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
+    </div>
+</div>
+
+<div class="o-forms o-forms--inline o-forms--error">
+    <div class="o-forms__inline-item">
+	    <label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
+	    <div class="o-forms__errortext">Invalid entry</div>
+    </div>
+    <div class="o-forms__inline-item">
+	    <textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
+    </div>
+</div>
+

--- a/demos/src/inline.mustache
+++ b/demos/src/inline.mustache
@@ -69,7 +69,6 @@
     <div class="o-forms__inline-container">
         <div class="o-forms__inline-item">
             <legend class="o-forms__label">Error</legend>
-            <div class="o-forms__errortext">Invalid entry</div>
         </div>
         <div class="o-forms__inline-item">
             <div class="o-forms__group">
@@ -78,6 +77,7 @@
                 <input type="checkbox" name="checkbox3" value="2" class="o-forms__checkbox" id="checkbox32" />
                 <label for="checkbox32" class="o-forms__label">Checkbox 2</label>
             </div>
+            <div class="o-forms__errortext">Invalid entry</div>
         </div>
     </div>
 </fieldset>
@@ -103,7 +103,6 @@
     <div class="o-forms__inline-container">
         <div class="o-forms__inline-item">
             <legend class="o-forms__label">Error</legend>
-            <div class="o-forms__errortext">Invalid entry</div>
         </div>
         <div class="o-forms__inline-item">
             <div class="o-forms__group">
@@ -112,6 +111,7 @@
                 <input type="radio" name="radio3" value="2" class="o-forms__radio" id="radio32" />
                 <label for="radio32" class="o-forms__label">Radio 2</label>
             </div>
+            <div class="o-forms__errortext">Invalid entry</div>
         </div>
     </div>
 </fieldset>
@@ -132,7 +132,6 @@
 <div class="o-forms o-forms--inline o-forms--error">
     <div class="o-forms__inline-item">
 	    <label for="select-invalid" class="o-forms__label">Select box (error)</label>
-	    <div class="o-forms__errortext">Invalid entry</div>
     </div>
     <div class="o-forms__inline-item">
         <select id="select-invalid" class="o-forms__select">
@@ -141,6 +140,7 @@
             <option value="option3">Option 3</option>
             <option value="option4">Option 4</option>
         </select>
+        <div class="o-forms__errortext">Invalid entry</div>
     </div>
 </div>
 
@@ -175,10 +175,10 @@
 <div class="o-forms o-forms--inline o-forms--error">
     <div class="o-forms__inline-item">
 	    <label for="o-forms-invalid" class="o-forms__label">URL input :invalid</label>
-        <div class="o-forms__errortext">Please enter a valid url</div>
     </div>
     <div class="o-forms__inline-item">
         <input type="url" id="o-forms-invalid" class="o-forms__text" value="hp://invalid.com" />
+        <div class="o-forms__errortext">Please enter a valid url</div>
     </div>
 </div>
 
@@ -195,10 +195,10 @@
 <div class="o-forms o-forms--inline o-forms--error">
     <div class="o-forms__inline-item">
 	    <label for="o-forms__textarea-invalid" class="o-forms__label">Textarea (error)</label>
-	    <div class="o-forms__errortext">Invalid entry</div>
     </div>
     <div class="o-forms__inline-item">
 	    <textarea id="o-forms__textarea-invalid" class="o-forms__textarea"></textarea>
+        <div class="o-forms__errortext">Invalid entry</div>
     </div>
 </div>
 

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -10,16 +10,14 @@
 			<label for="checkboxToggle2" class="o-forms__label">Checkbox Toggle 2</label>
 		</div>
 	</div>
-	<div class="inverse-demo">
-		<div class="o-forms__group">
-			<div class="o-forms__toggle o-forms__toggle--inverse">
-				<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle3" />
-				<label for="checkboxToggle3" class="o-forms__label">Checkbox Toggle 3 (Inverse)</label>
-			</div>
-			<div class="o-forms__toggle o-forms__toggle--inverse">
-				<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle4" checked="checked" />
-				<label for="checkboxToggle4" class="o-forms__label">Checkbox Toggle 4 (Inverse)</label>
-			</div>
+	<div class="o-forms__group inverse-demo">
+		<div class="o-forms__toggle o-forms__toggle--inverse">
+			<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle3" />
+			<label for="checkboxToggle3" class="o-forms__label">Checkbox Toggle 3 (Inverse)</label>
+		</div>
+		<div class="o-forms__toggle o-forms__toggle--inverse">
+			<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle4" checked="checked" />
+			<label for="checkboxToggle4" class="o-forms__label">Checkbox Toggle 4 (Inverse)</label>
 		</div>
 	</div>
 </fieldset>

--- a/demos/src/radios-button-styling.mustache
+++ b/demos/src/radios-button-styling.mustache
@@ -39,7 +39,7 @@
         <input type="radio" name="radio6" value="no" class="o-forms__radio-button" id="radio62" />
         <label for="radio62" class="o-forms__label">No</label>
     </div>
-    <div class="o-forms__errortext">Please select either Yes or No</div>
+    <div class="o-forms__errortext">We were unable to update your preference, please try again.</div>
 </fieldset>
 
 <fieldset class="o-forms">

--- a/demos/src/radios.mustache
+++ b/demos/src/radios.mustache
@@ -1,6 +1,6 @@
 <fieldset class="o-forms">
-	<legend class="o-forms__label">Default radio controls</legend>
-	<div class="o-forms__additional-info">Prompt text follows the legend if required.</div>
+	<legend aria-describedby="default-radio-info" class="o-forms__label">Default radio controls</legend>
+	<div id="default-radio-info" class="o-forms__additional-info">Prompt text follows the legend if required.</div>
 	<div class="o-forms__group">
 		<input type="radio" name="radio-a" value="1" class="o-forms__radio" id="radio11" checked="checked" />
 		<label for="radio11" class="o-forms__label">Radio 1</label>

--- a/demos/src/select-boxes.mustache
+++ b/demos/src/select-boxes.mustache
@@ -1,6 +1,6 @@
 <div class="o-forms">
-	<label for="select-standard" class="o-forms__label">Select box</label>
-	<div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+	<label aria-describedby="select-box-info" for="select-standard" class="o-forms__label">Select box</label>
+	<div id="select-box-info" class="o-forms__additional-info">Prompt text follows the label if required.</div>
 	<select id="select-standard" class="o-forms__select">
 		<option value="option1" selected>Option 1</option>
 		<option value="option2">Option 2</option>

--- a/demos/src/text-inputs.mustache
+++ b/demos/src/text-inputs.mustache
@@ -1,6 +1,6 @@
 <div class="o-forms">
-	<label for="o-forms-standard" class="o-forms__label">Text input</label>
-	<div class="o-forms__additional-info">Prompt text follows the label if required..</div>
+	<label aria-describedby="text-box-info" for="o-forms-standard" class="o-forms__label">Text input</label>
+	<div id="text-box-info" class="o-forms__additional-info">Prompt text follows the label if required..</div>
 	<input type="text" id="o-forms-standard" class="o-forms__text" required />
 </div>
 

--- a/demos/src/textareas.mustache
+++ b/demos/src/textareas.mustache
@@ -1,6 +1,6 @@
 <div class="o-forms">
-	<label for="o-forms__textarea" class="o-forms__label">Textarea</label>
-	<div class="o-forms__additional-info">Prompt text follows the label if required.</div>
+	<label aria-describedby="textarea-info" for="o-forms__textarea" class="o-forms__label">Textarea</label>
+	<div id="textarea-info" class="o-forms__additional-info">Prompt text follows the label if required.</div>
 	<textarea id="o-forms__textarea" class="o-forms__textarea"></textarea>
 </div>
 

--- a/demos/src/toggle.mustache
+++ b/demos/src/toggle.mustache
@@ -10,16 +10,14 @@
 			<label for="checkboxToggle2" class="o-forms__label">Checkbox Toggle 2</label>
 		</div>
 	</div>
-	<div class="inverse-demo">
-		<div class="o-forms__group">
-			<div class="o-forms__toggle o-forms__toggle--inverse">
-				<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle3" />
-				<label for="checkboxToggle3" class="o-forms__label">Checkbox Toggle 3 (Inverse)</label>
-			</div>
-			<div class="o-forms__toggle o-forms__toggle--inverse">
-				<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle4" checked="checked" />
-				<label for="checkboxToggle4" class="o-forms__label">Checkbox Toggle 4 (Inverse)</label>
-			</div>
+	<div class="o-forms__group inverse-demo">
+		<div class="o-forms__toggle o-forms__toggle--inverse">
+			<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle3" />
+			<label for="checkboxToggle3" class="o-forms__label">Checkbox Toggle 3 (Inverse)</label>
+		</div>
+		<div class="o-forms__toggle o-forms__toggle--inverse">
+			<input class="o-forms__toggle__checkbox" data-o-form-toggle type="checkbox" name="checkbox" value="1" id="checkboxToggle4" checked="checked" />
+			<label for="checkboxToggle4" class="o-forms__label">Checkbox Toggle 4 (Inverse)</label>
 		</div>
 	</div>
 </fieldset>

--- a/origami.json
+++ b/origami.json
@@ -69,6 +69,12 @@
 			"description": "These are optional section wrappers to highlight multiple instances of o-forms."
 		},
 		{
+			"name": "inline",
+			"title": "Inline",
+			"template": "/demos/src/inline.mustache",
+			"description": "Form elements may also be displayed inline."
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "/demos/src/pa11y.mustache",

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -31,7 +31,6 @@ $_o-forms-field-default-font-size: 14px;
 /// @access private
 /// @type String
 $_o-forms-group-spacing: oTypographySpacingSize(5); // 20px
-$_o-forms-group-item-spacing: oTypographySpacingSize(5); // 20px
 $_o-forms-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-legend-spacing: oTypographySpacingSize(2); // 8px
 $_o-forms-checkbox-horizontal-spacing: 15px;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -31,6 +31,7 @@ $_o-forms-field-default-font-size: 14px;
 /// @access private
 /// @type String
 $_o-forms-group-spacing: oTypographySpacingSize(5); // 20px
+$_o-forms-group-item-spacing: oTypographySpacingSize(5); // 20px
 $_o-forms-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-legend-spacing: oTypographySpacingSize(2); // 8px
 $_o-forms-checkbox-horizontal-spacing: 15px;
@@ -42,6 +43,7 @@ $_o-forms-padding: oGridGutter();
 $_o-forms-field-default-height: 40px;  // align it to the big button size
 $_o-forms-field-small-height: 28px; // align it to the regular button size
 $_o-forms-field-max-width: 380px; // This is meant to be 1/3 of the columns in the full grid, should probably be using an o-grid function
+$_o-forms-inline-field-max-width: 470px; // 12/5 full grid width (5 cols)
 
 /// Field and label padding variables.
 /// big button 40px, line height 20px, border 1px

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -31,6 +31,7 @@ $_o-forms-field-default-font-size: 14px;
 /// @access private
 /// @type String
 $_o-forms-group-spacing: oTypographySpacingSize(5); // 20px
+$_o-forms-inline-group-spacing: oTypographySpacingSize(8); // 32px
 $_o-forms-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-legend-spacing: oTypographySpacingSize(2); // 8px
 $_o-forms-checkbox-horizontal-spacing: 15px;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -43,7 +43,7 @@ $_o-forms-padding: oGridGutter();
 $_o-forms-field-default-height: 40px;  // align it to the big button size
 $_o-forms-field-small-height: 28px; // align it to the regular button size
 $_o-forms-field-max-width: 380px; // This is meant to be 1/3 of the columns in the full grid, should probably be using an o-grid function
-$_o-forms-inline-field-max-width: 470px; // 12/5 full grid width (5 cols)
+$_o-forms-inline-field-max-width: 470px; // 5/12 full grid width (5 cols)
 
 /// Field and label padding variables.
 /// big button 40px, line height 20px, border 1px

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -37,6 +37,10 @@
 	.#{$class} {
 		@include oFormsGroup;
 	}
+	.#{$class}__inline-container,
+	.#{$class}--inline {
+		@include oFormsGroupInline;
+	}
 	.#{$class}__text,
 	.#{$class}__select,
 	.#{$class}__textarea {

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -137,9 +137,13 @@
 /// @require {mixin} oFormsBaseFeatures - Basic form features must be output for the styled radio buttons to work.
 /// @output Styles for radios which look like a group of buttons, where one can be selected.
 @mixin oFormsRadioButtonsStyledFeature($class: 'o-forms') {
-    .#{$class}__radio-button {
-      @include oFormsRadioButtonsStyled($class);
-    }
+	.#{$class}__radio-button {
+		@include oFormsRadioButtonsStyled($class);
+	}
+	// Errors.
+	.#{$class}--error .#{$class}__radio-button {
+		@include _oFormsRadioButtonsStyledInvalid;
+	}
 }
 
 /// @access public

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -22,6 +22,8 @@
 	@include oFormsCheckboxToggleFeature($class);
 	// Sections.
 	@include oFormsSectionFeature($class);
+	// Inline Forms.
+	@include oFormsInlineFeature($class);
 	// Small modifer.
 	@include oFormsSmallFeature($class);
 	// Wide modifer.
@@ -36,21 +38,6 @@
 @mixin oFormsBaseFeatures($class: 'o-forms') {
 	.#{$class} {
 		@include oFormsGroup;
-	}
-	.#{$class}--inline {
-		@include oFormsGroupInline;
-	}
-	// `fieldset.o-forms--inline` must nest `.o-forms__inline-container` as fieldset may override the display value.
-	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-	.#{$class}--inline,
-	.#{$class}__inline-container {
-		@include oFormsGroupInlineContainer;
-	}
-	.#{$class}--inline.#{$class}--radios,
-	.#{$class}--inline.#{$class}--checkboxes,
-	.#{$class}--radios .#{$class}__inline-container,
-	.#{$class}--checkboxes .#{$class}__inline-container {
-		@include oFormsGroupInlineRadioCheckbox;
 	}
 	.#{$class}__text,
 	.#{$class}__select,
@@ -165,6 +152,26 @@
 	}
 	.#{$class}__suffix {
 		@include oFormsSuffix;
+	}
+}
+
+/// @access public
+/// @param {string} $class - The block level class name (BEM naming convention).
+/// @require {mixin} oFormsBaseFeatures - Basic form features must be output for inline modifiers to work.
+/// @output Styles to support inline forms, with labels/messaging to one side and inputs to the other.
+@mixin oFormsInlineFeature($class: 'o-forms') {
+	.#{$class}--inline {
+		@include oFormsGroupInline;
+	}
+	.#{$class}--inline,
+	.#{$class}__inline-container {
+		@include oFormsGroupInlineContainer;
+	}
+	.#{$class}--inline.#{$class}--radios,
+	.#{$class}--inline.#{$class}--checkboxes,
+	.#{$class}--radios .#{$class}__inline-container,
+	.#{$class}--checkboxes .#{$class}__inline-container {
+		@include oFormsGroupInlineRadioCheckbox;
 	}
 }
 

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -40,9 +40,17 @@
 	.#{$class}--inline {
 		@include oFormsGroupInline;
 	}
+	// `fieldset.o-forms--inline` must nest `.o-forms__inline-container` as fieldset may override the display value.
+	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
 	.#{$class}--inline,
 	.#{$class}__inline-container {
-		@include oFormsInlineContainer;
+		@include oFormsGroupInlineContainer;
+	}
+	.#{$class}--inline.#{$class}--radios,
+	.#{$class}--inline.#{$class}--checkboxes,
+	.#{$class}--radios .#{$class}__inline-container,
+	.#{$class}--checkboxes .#{$class}__inline-container {
+		@include oFormsGroupInlineRadioCheckbox;
 	}
 	.#{$class}__text,
 	.#{$class}__select,

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -37,9 +37,12 @@
 	.#{$class} {
 		@include oFormsGroup;
 	}
-	.#{$class}__inline-container,
 	.#{$class}--inline {
 		@include oFormsGroupInline;
+	}
+	.#{$class}--inline,
+	.#{$class}__inline-container {
+		@include oFormsInlineContainer;
 	}
 	.#{$class}__text,
 	.#{$class}__select,

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -20,47 +20,72 @@
 	// sass-lint:enable mixins-before-declarations
 }
 
+/// @access public
+/// @require {mixin} oFormsGroup
+/// @output Styles to modify the o-forms/fieldset group for inline fields.
 @mixin oFormsGroupInline($class: 'o-forms') {
-	margin: 0 0 $_o-forms-inline-group-spacing;
+	@include oGridRespondTo(S) {
+		margin: 0 0 $_o-forms-inline-group-spacing;
+	}
 }
 
-@mixin oFormsInlineContainer($class: 'o-forms') {
-	max-width: $_o-forms-inline-field-max-width;
-	// Fieldset overrides the display vaule in some browsers.
-	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-	&:not(fieldset) {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		grid-gap: 20px;
-		align-items: center;
-		// IE10 - IE11 Support
-		// sass-lint:disable no-vendor-prefixes
-		-ms-grid-columns: 1fr 20px 1fr;
-		counter-reset: inline-item; // 0
-		> .o-forms__inline-item {
-			counter-increment: inline-item;
-			-ms-grid-row: counter(inline-item);
-			-ms-grid-row-align: center;
-			-ms-grid-column: 1;
-			> .o-forms__label {
-				max-width: 100%;
-			}
-		}
-		> .o-forms__inline-item:nth-child(even) {
-			-ms-grid-column: 3;
-		}
-		// sass-lint:enable no-vendor-prefixes
+/// @access public
+/// @require {mixin} oFormsGroup
+/// @require {mixin} oFormsGroupInline
+/// @output Styles to modify the alignment of inline o-forms/fieldset group for checkboxes and radio buttons.
+@mixin oFormsGroupInlineRadioCheckbox($class: 'o-forms') {
+	align-items: baseline;
+}
 
-		// Remove verticle margins from "inputs".
-		.#{$class}__group {
-			margin-top: -($_o-forms-group-spacing / 2);
-			margin-bottom: -($_o-forms-group-spacing / 2);
-		}
-		.#{$class}__affix-wrapper,
-		.#{$class}__text,
-		.#{$class}__select,
-		.#{$class}__textarea {
-			margin-top: 0;
+/// @access public
+/// @require {mixin} oFormsGroup
+/// @require {mixin} oFormsGroupInline
+/// @output Styles for the o-forms/fieldset inline container.
+@mixin oFormsGroupInlineContainer($class: 'o-forms') {
+	@include oGridRespondTo(S) {
+		max-width: $_o-forms-inline-field-max-width;
+		// Fieldset overrides the display vaule in some browsers.
+		// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+		&:not(fieldset) {
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			grid-column-gap: 20px;
+			-ms-grid-columns: 1fr 20px 1fr;
+			align-items: center;
+
+			> .#{$class}__label,
+			> .#{$class}__inline-item,
+			> .#{$class}__additional-info {
+				grid-column: 1;
+			}
+
+			> .#{$class}__affix-wrapper,
+			> .#{$class}__text,
+			> .#{$class}__select,
+			> .#{$class}__textarea,
+			> .#{$class}__group {
+				grid-column: 2;
+				-ms-grid-column: 3;
+				grid-row: 1;
+			}
+
+			> .#{$class}__errortext {
+				grid-column: 2;
+				-ms-grid-column: 3;
+				grid-row: 2;
+			}
+
+			// Remove verticle margins from "inputs".
+			.#{$class}__group {
+				margin-top: -($_o-forms-group-spacing / 2);
+				margin-bottom: -($_o-forms-group-spacing / 2);
+			}
+			.#{$class}__affix-wrapper,
+			.#{$class}__text,
+			.#{$class}__select,
+			.#{$class}__textarea {
+				margin-top: 0;
+			}
 		}
 	}
 }

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -49,8 +49,8 @@
 
 		// Remove verticle margins from "inputs".
 		.#{$class}__group {
-			margin-top: -($_o-forms-group-item-spacing / 2);
-			margin-bottom: -($_o-forms-group-item-spacing / 2);
+			margin-top: -($_o-forms-group-spacing / 2);
+			margin-bottom: -($_o-forms-group-spacing / 2);
 		}
 		.#{$class}__affix-wrapper,
 		.#{$class}__text,

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -11,6 +11,7 @@
 	// reset <fieldset> defaults
 	padding: 0;
 	border: 0;
+	min-width: auto;
 
 	// sass-lint:disable mixins-before-declarations
 	@include oGridRespondTo(S) {
@@ -25,7 +26,16 @@
 /// @output Styles to modify the o-forms/fieldset group for inline fields.
 @mixin oFormsGroupInline($class: 'o-forms') {
 	@include oGridRespondTo(S) {
-		margin: 0 0 $_o-forms-inline-group-spacing;
+		@supports (display: grid) {
+			max-width: $_o-forms-inline-field-max-width;
+			margin: 0 0 $_o-forms-inline-group-spacing;
+		}
+		// IE10-11 (no @supports but its own grid
+		&,
+		_:-ms-lang(x) {
+			max-width: $_o-forms-inline-field-max-width;
+			margin: 0 0 $_o-forms-inline-group-spacing;
+		}
 	}
 }
 
@@ -35,6 +45,16 @@
 /// @output Styles to modify the alignment of inline o-forms/fieldset group for checkboxes and radio buttons.
 @mixin oFormsGroupInlineRadioCheckbox($class: 'o-forms') {
 	align-items: baseline;
+	@include _oFormsMessagingElements($class) {
+		align-self: baseline;
+		-ms-grid-row-align: start; // IE10-11 no baseline support
+	}
+}
+
+@mixin oFormsGroupInlineTextArea($class: 'o-forms') {
+	@include _oFormsMessagingElements($class) {
+		align-self: start;
+	}
 }
 
 /// @access public
@@ -43,50 +63,94 @@
 /// @output Styles for the o-forms/fieldset inline container.
 @mixin oFormsGroupInlineContainer($class: 'o-forms') {
 	@include oGridRespondTo(S) {
-		max-width: $_o-forms-inline-field-max-width;
 		// Fieldset overrides the display vaule in some browsers.
 		// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
 		&:not(fieldset) {
+			// sass-lint:disable no-vendor-prefixes
 			display: grid;
 			grid-template-columns: repeat(2, 1fr);
 			grid-column-gap: 20px;
 			-ms-grid-columns: 1fr 20px 1fr;
-			align-items: center;
+			align-items: start;
+			min-width: 0;
 
-			> .#{$class}__label,
-			> .#{$class}__inline-item,
-			> .#{$class}__additional-info {
+			@include _oFormsMessagingElements($class) {
 				grid-column: 1;
+				align-self: center;
 			}
 
+			// Explicitly position input elements in the css grid .
+			// IE10-11 do not support auto placement.
 			> .#{$class}__affix-wrapper,
 			> .#{$class}__text,
 			> .#{$class}__select,
 			> .#{$class}__textarea,
-			> .#{$class}__group {
+			> .#{$class}__group,
+			> .#{$class}__inline-item--left {
 				grid-column: 2;
-				-ms-grid-column: 3;
+				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap
 				grid-row: 1;
+				-ms-grid-row-align: start; // IE10-11 increases input height to grid cell without alignment
 			}
 
+			// Explicitly position error text in the css grid .
+			// IE10-11 do not support auto placement.
 			> .#{$class}__errortext {
 				grid-column: 2;
-				-ms-grid-column: 3;
+				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap
 				grid-row: 2;
 			}
 
-			// Remove verticle margins from "inputs".
-			.#{$class}__group {
+			// For long labels and additional text which should span
+			// error text and not aign to the start of the input.
+			> .#{$class}__inline-item--long {
+				align-self: start;
+				grid-row: 1 / span 3;
+			}
+
+			// Reset margins only if grid is supported.
+			@supports (display: grid) {
+				> .#{$class}__affix-wrapper,
+				> .#{$class}__text,
+				> .#{$class}__select,
+				> .#{$class}__textarea,
+				> .#{$class}__group,
+				> .#{$class}__inline-item--left {
+					margin-top: 0;
+				}
+				> .#{$class}__group {
+					margin-top: -($_o-forms-group-spacing / 2);
+					margin-bottom: -($_o-forms-group-spacing / 2);
+				}
+			}
+
+			// Reset margins for IE10-11 (@supports unsupported)
+			_:-ms-lang(x),
+			> .#{$class}__affix-wrapper,
+			> .#{$class}__text,
+			> .#{$class}__select,
+			> .#{$class}__textarea,
+			> .#{$class}__group,
+			> .#{$class}__inline-item--left {
+				margin-top: 0;
+			}
+			_:-ms-lang(x),
+			> .#{$class}__group {
 				margin-top: -($_o-forms-group-spacing / 2);
 				margin-bottom: -($_o-forms-group-spacing / 2);
 			}
-			.#{$class}__affix-wrapper,
-			.#{$class}__text,
-			.#{$class}__select,
-			.#{$class}__textarea {
-				margin-top: 0;
-			}
 		}
+		// sass-lint:enable no-vendor-prefixes
+	}
+}
+
+/// @access private
+/// @output A provided content block wrapped in selectors for form messaging, such as labels and additonal info.
+@mixin _oFormsMessagingElements($class: 'o-forms') {
+	> .#{$class}__label,
+	> .#{$class}__additional-info,
+	> .#{$class}__inline-item {
+		@content;
 	}
 }
 

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -22,13 +22,6 @@
 
 @mixin oFormsGroupInline($class: 'o-forms') {
 	max-width: $_o-forms-inline-field-max-width;
-	.#{$class}__label {
-		margin-bottom: 0;
-	}
-	.#{$class}__label + .#{$class}__additional-info {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
 	// Fieldset overrides the display vaule in some browsers.
 	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
 	&:not(fieldset) {
@@ -53,6 +46,18 @@
 			-ms-grid-column: 3;
 		}
 		// sass-lint:enable no-vendor-prefixes
+
+		// Remove verticle margins from "inputs".
+		.#{$class}__group {
+			margin-top: -($_o-forms-group-item-spacing / 2);
+			margin-bottom: -($_o-forms-group-item-spacing / 2);
+		}
+		.#{$class}__affix-wrapper,
+		.#{$class}__text,
+		.#{$class}__select,
+		.#{$class}__textarea {
+			margin-top: 0;
+		}
 	}
 }
 
@@ -64,6 +69,7 @@
 		color: oBrandGet('field-standard-text');
 		border-color: oBrandGet('field-standard-border');
 		background-color: oBrandGet('field-standard-background');
+		margin-top: $_o-forms-spacing;
 		box-sizing: border-box;
 		width: 100%;
 		max-width: $_o-forms-field-max-width;

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -20,6 +20,42 @@
 	// sass-lint:enable mixins-before-declarations
 }
 
+@mixin oFormsGroupInline($class: 'o-forms') {
+	max-width: $_o-forms-inline-field-max-width;
+	.#{$class}__label {
+		margin-bottom: 0;
+	}
+	.#{$class}__label + .#{$class}__additional-info {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+	// Fieldset overrides the display vaule in some browsers.
+	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+	&:not(fieldset) {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		grid-gap: 20px;
+		align-items: center;
+		// IE10 - IE11 Support
+		// sass-lint:disable no-vendor-prefixes
+		-ms-grid-columns: 1fr 20px 1fr;
+		counter-reset: inline-item; // 0
+		> .o-forms__inline-item {
+			counter-increment: inline-item;
+			-ms-grid-row: counter(inline-item);
+			-ms-grid-row-align: center;
+			-ms-grid-column: 1;
+			> .o-forms__label {
+				max-width: 100%;
+			}
+		}
+		> .o-forms__inline-item:nth-child(even) {
+			-ms-grid-column: 3;
+		}
+		// sass-lint:enable no-vendor-prefixes
+	}
+}
+
 /// @access public
 /// @output Basic styles shared between input, textarea, select etc.
 @mixin oFormsCommonFieldBase {
@@ -28,7 +64,6 @@
 		color: oBrandGet('field-standard-text');
 		border-color: oBrandGet('field-standard-border');
 		background-color: oBrandGet('field-standard-background');
-		margin-top: $_o-forms-spacing;
 		box-sizing: border-box;
 		width: 100%;
 		max-width: $_o-forms-field-max-width;

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -45,14 +45,14 @@
 /// @output Styles to modify the alignment of inline o-forms/fieldset group for checkboxes and radio buttons.
 @mixin oFormsGroupInlineRadioCheckbox($class: 'o-forms') {
 	align-items: baseline;
-	@include _oFormsMessagingElements($class) {
+	@include _oFormsMessagingElementSelectors($class) {
 		align-self: baseline;
 		-ms-grid-row-align: start; // IE10-11 no baseline support
 	}
 }
 
 @mixin oFormsGroupInlineTextArea($class: 'o-forms') {
-	@include _oFormsMessagingElements($class) {
+	@include _oFormsMessagingElementSelectors($class) {
 		align-self: start;
 	}
 }
@@ -63,7 +63,7 @@
 /// @output Styles for the o-forms/fieldset inline container.
 @mixin oFormsGroupInlineContainer($class: 'o-forms') {
 	@include oGridRespondTo(S) {
-		// Fieldset overrides the display vaule in some browsers.
+		// Fieldsets must use a container element, as fieldsets override the display vaule in some browsers.
 		// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
 		&:not(fieldset) {
 			// sass-lint:disable no-vendor-prefixes
@@ -74,23 +74,28 @@
 			align-items: start;
 			min-width: 0;
 
-			@include _oFormsMessagingElements($class) {
+			@include _oFormsMessagingElementSelectors($class) {
 				grid-column: 1;
 				align-self: center;
 			}
 
 			// Explicitly position input elements in the css grid .
 			// IE10-11 do not support auto placement.
-			> .#{$class}__affix-wrapper,
-			> .#{$class}__text,
-			> .#{$class}__select,
-			> .#{$class}__textarea,
-			> .#{$class}__group,
-			> .#{$class}__inline-item--left {
+			@include _oFormsInputElementSelectors($class) {
 				grid-column: 2;
 				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap
 				grid-row: 1;
 				-ms-grid-row-align: start; // IE10-11 increases input height to grid cell without alignment
+				// Reset margins only if grid is supported.
+				@supports (display: grid) {
+					margin-top: 0;
+				}
+				// Reset margins for IE10-11 (@supports unsupported)
+				@at-root {
+					&, _:-ms-lang(x) {
+						margin-top: 0;
+					}
+				}
 			}
 
 			// Explicitly position error text in the css grid .
@@ -107,29 +112,6 @@
 				align-self: start;
 				grid-row: 1 / span 3;
 			}
-
-			// Reset margins only if grid is supported.
-			@supports (display: grid) {
-				> .#{$class}__affix-wrapper,
-				> .#{$class}__text,
-				> .#{$class}__select,
-				> .#{$class}__textarea,
-				> .#{$class}__group,
-				> .#{$class}__inline-item--left {
-					margin-top: 0;
-				}
-			}
-
-			// Reset margins for IE10-11 (@supports unsupported)
-			_:-ms-lang(x),
-			> .#{$class}__affix-wrapper,
-			> .#{$class}__text,
-			> .#{$class}__select,
-			> .#{$class}__textarea,
-			> .#{$class}__group,
-			> .#{$class}__inline-item--left {
-				margin-top: 0;
-			}
 		}
 		// sass-lint:enable no-vendor-prefixes
 	}
@@ -137,10 +119,23 @@
 
 /// @access private
 /// @output A provided content block wrapped in selectors for form messaging, such as labels and additonal info.
-@mixin _oFormsMessagingElements($class: 'o-forms') {
+@mixin _oFormsMessagingElementSelectors($class: 'o-forms') {
 	> .#{$class}__label,
 	> .#{$class}__additional-info,
 	> .#{$class}__inline-item {
+		@content;
+	}
+}
+
+/// @access private
+/// @output A provided content block wrapped in selectors for form input elements / groups.
+@mixin _oFormsInputElementSelectors($class: 'o-forms') {
+	> .#{$class}__affix-wrapper,
+	> .#{$class}__text,
+	> .#{$class}__select,
+	> .#{$class}__textarea,
+	> .#{$class}__group,
+	> .#{$class}__inline-item--left {
 		@content;
 	}
 }

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -51,12 +51,6 @@
 	}
 }
 
-@mixin oFormsGroupInlineTextArea($class: 'o-forms') {
-	@include _oFormsMessagingElementSelectors($class) {
-		align-self: start;
-	}
-}
-
 /// @access public
 /// @require {mixin} oFormsGroup
 /// @require {mixin} oFormsGroupInline

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -118,10 +118,6 @@
 				> .#{$class}__inline-item--left {
 					margin-top: 0;
 				}
-				> .#{$class}__group {
-					margin-top: -($_o-forms-group-spacing / 2);
-					margin-bottom: -($_o-forms-group-spacing / 2);
-				}
 			}
 
 			// Reset margins for IE10-11 (@supports unsupported)
@@ -133,11 +129,6 @@
 			> .#{$class}__group,
 			> .#{$class}__inline-item--left {
 				margin-top: 0;
-			}
-			_:-ms-lang(x),
-			> .#{$class}__group {
-				margin-top: -($_o-forms-group-spacing / 2);
-				margin-bottom: -($_o-forms-group-spacing / 2);
 			}
 		}
 		// sass-lint:enable no-vendor-prefixes

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -21,6 +21,10 @@
 }
 
 @mixin oFormsGroupInline($class: 'o-forms') {
+	margin: 0 0 $_o-forms-inline-group-spacing;
+}
+
+@mixin oFormsInlineContainer($class: 'o-forms') {
 	max-width: $_o-forms-inline-field-max-width;
 	// Fieldset overrides the display vaule in some browsers.
 	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -31,11 +31,13 @@
 			margin: 0 0 $_o-forms-inline-group-spacing;
 		}
 		// IE10-11 (no @supports but its own grid
+		// sass-lint:disable no-vendor-prefixes
 		&,
 		_:-ms-lang(x) {
 			max-width: $_o-forms-inline-field-max-width;
 			margin: 0 0 $_o-forms-inline-group-spacing;
 		}
+		// sass-lint:enable no-vendor-prefixes
 	}
 }
 
@@ -44,11 +46,11 @@
 /// @require {mixin} oFormsGroupInline
 /// @output Styles to modify the alignment of inline o-forms/fieldset group for checkboxes and radio buttons.
 @mixin oFormsGroupInlineRadioCheckbox($class: 'o-forms') {
-	align-items: baseline;
 	@include _oFormsMessagingElementSelectors($class) {
 		align-self: baseline;
-		-ms-grid-row-align: start; // IE10-11 no baseline support
+		-ms-grid-row-align: start; // sass-lint:disable-line no-vendor-prefixes IE10-11 no baseline support
 	}
+	align-items: baseline;
 }
 
 /// @access public
@@ -59,13 +61,12 @@
 	@include oGridRespondTo(S) {
 		// Fieldsets must use a container element, as fieldsets override the display vaule in some browsers.
 		// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+		// sass-lint:disable mixins-before-declarations no-vendor-prefixes
 		&:not(fieldset) {
-			// sass-lint:disable no-vendor-prefixes
 			display: grid;
 			grid-template-columns: repeat(2, 1fr);
 			grid-column-gap: 20px;
 			-ms-grid-columns: 1fr 20px 1fr;
-			align-items: start;
 			min-width: 0;
 
 			@include _oFormsMessagingElementSelectors($class) {
@@ -73,42 +74,42 @@
 				align-self: center;
 			}
 
-			// Explicitly position input elements in the css grid .
+			// Explicitly position input elements in the css grid.
 			// IE10-11 do not support auto placement.
 			@include _oFormsInputElementSelectors($class) {
 				grid-column: 2;
-				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap
+				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
 				grid-row: 1;
-				-ms-grid-row-align: start; // IE10-11 increases input height to grid cell without alignment
+				align-self: start; // IE10-11 defaults to stretch with align-items.
 				// Reset margins only if grid is supported.
 				@supports (display: grid) {
 					margin-top: 0;
 				}
-				// Reset margins for IE10-11 (@supports unsupported)
+				// Reset margins for IE10-11 (@supports unsupported).
 				@at-root {
-					&, _:-ms-lang(x) {
+					&,
+					_:-ms-lang(x) {
 						margin-top: 0;
 					}
 				}
 			}
 
-			// Explicitly position error text in the css grid .
-			// IE10-11 do not support auto placement.
+			// Explicitly position error text in the css grid.
 			> .#{$class}__errortext {
 				grid-column: 2;
-				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap
+				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
 				grid-row: 2;
 			}
 
-			// For long labels and additional text which should span
-			// error text and not aign to the start of the input.
+			// For long labels and or additional text.
+			// Spans error text so the error text is against its input.
 			> .#{$class}__inline-item--long {
 				align-self: start;
 				grid-row: 1 / span 3;
 			}
 		}
-		// sass-lint:enable no-vendor-prefixes
 	}
+	// sass-lint:enable mixins-before-declarations no-vendor-prefixes
 }
 
 /// @access private

--- a/src/scss/mixins/_labels.scss
+++ b/src/scss/mixins/_labels.scss
@@ -11,6 +11,7 @@
 		color: oBrandGet('field-label-text');
 		display: block;
 		padding: 0; // Reset legend default styling
+		margin-bottom: $_o-forms-checkbox-legend-spacing;
 		p {
 			@include oTypographyMargin($top: 0, $bottom: 2);
 
@@ -22,12 +23,24 @@
 }
 
 /// @access public
+/// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles for addional input information (typically below a label).
-@mixin oFormsAdditionalInfo {
+@mixin oFormsAdditionalInfo($class: 'o-forms') {
 	@include oBrandConfigureFor('o-forms') {
 		@include oTypographySize($_o-forms-typography-scale-small);
 		color: oBrandGet('field-additional-info-text');
 		display: block;
+		& + .#{$class}__text,
+		& + .#{$class}__select,
+		& + .#{$class}__textarea {
+			margin-top: $_o-forms-spacing - $_o-forms-checkbox-legend-spacing;
+		}
+		@at-root {
+			.#{$class}__label + & {
+				margin-top: -$_o-forms-checkbox-legend-spacing;
+				margin-bottom: $_o-forms-checkbox-legend-spacing;
+			}
+		}
 	}
 }
 

--- a/src/scss/mixins/_labels.scss
+++ b/src/scss/mixins/_labels.scss
@@ -11,7 +11,6 @@
 		color: oBrandGet('field-label-text');
 		display: block;
 		padding: 0; // Reset legend default styling
-		margin-bottom: $_o-forms-checkbox-legend-spacing;
 		p {
 			@include oTypographyMargin($top: 0, $bottom: 2);
 
@@ -23,24 +22,12 @@
 }
 
 /// @access public
-/// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles for addional input information (typically below a label).
-@mixin oFormsAdditionalInfo($class: 'o-forms') {
+@mixin oFormsAdditionalInfo {
 	@include oBrandConfigureFor('o-forms') {
 		@include oTypographySize($_o-forms-typography-scale-small);
 		color: oBrandGet('field-additional-info-text');
 		display: block;
-		& + .#{$class}__text,
-		& + .#{$class}__select,
-		& + .#{$class}__textarea {
-			margin-top: $_o-forms-spacing - $_o-forms-checkbox-legend-spacing;
-		}
-		@at-root {
-			.#{$class}__label + & {
-				margin-top: -$_o-forms-checkbox-legend-spacing;
-				margin-bottom: $_o-forms-checkbox-legend-spacing;
-			}
-		}
 	}
 }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -125,16 +125,18 @@
 
     // Stacked radios/checkboxes.
     // @breaking Remove the not selectors by removing the need to override label margins.
-    .o-forms__toggle,
-    input + .#{$class}__label {
-        display: block;
-        box-sizing: border-box;
-        margin: $_o-forms-group-spacing 0;
-        &:first-of-type {
-            margin-top: 0;
-        }
-        &:last-of-type {
-            margin-bottom: 0;
+    &:not(#{&}--inline-together):not(#{&}--inline) {
+        .o-forms__toggle,
+        input + .#{$class}__label {
+            display: block;
+            box-sizing: border-box;
+            margin: $_o-forms-group-spacing 0;
+            &:first-of-type {
+                margin-top: 0;
+            }
+            &:last-of-type {
+                margin-bottom: 0;
+            }
         }
     }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -122,7 +122,8 @@
     margin-top: $_o-forms-checkbox-legend-spacing;
 
     // Stack grouped radios/checkboxes by default.
-    &:not(#{&}--inline-together){
+    // @breaking Label specifc margins or override them with `--stacked` rather.
+    &:not(#{&}--inline-together):not(#{&}--inline) {
         .o-forms__toggle,
         input + .#{$class}__label {
             display: block;
@@ -147,12 +148,6 @@
             display: inline-block;
             width: auto;
             margin: $group-item-verticle-spacing $_o-forms-checkbox-horizontal-spacing $group-item-verticle-spacing 0;
-            &:first-of-type {
-                margin-top: $group-item-verticle-spacing;
-            }
-            &:last-of-type {
-                margin-bottom: $group-item-verticle-spacing;
-            }
         }
     }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -124,7 +124,6 @@
     margin-top: $_o-forms-checkbox-legend-spacing;
 
     // Stacked radios/checkboxes.
-    // @breaking Remove the not selectors by removing the need to override label margins.
     .o-forms__toggle,
     input + .#{$class}__label {
         display: block;

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -121,8 +121,8 @@
 @mixin oFormsGroupContainer($class: 'o-forms') {
     margin-top: $_o-forms-checkbox-legend-spacing;
 
-    // Stack grouped radios/checkboxes by default.
-    // @breaking Label specifc margins or override them with `--stacked` rather.
+    // Stacked radios/checkboxes.
+    // @breaking Remove the not selectors by removing the need to override label margins.
     &:not(#{&}--inline-together):not(#{&}--inline) {
         .o-forms__toggle,
         input + .#{$class}__label {

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -20,7 +20,7 @@
             background-color: oBrandGet('checkbox-radio-checked-background');
             // sass-lint:disable no-vendor-prefixes
             @media screen and (-ms-high-contrast: active) {
-                    background-color: windowText;
+                background-color: windowText;
             }
             // sass-lint:enable no-vendor-prefixes
             // Equivalent to border-radius 50%. Fixes an old WebKit bug where rounding wouldn't be applied properly
@@ -119,12 +119,12 @@
 /// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles to wrap a group of checkboxes or a group of radios for purposes of positioning etc.
 @mixin oFormsGroupContainer($class: 'o-forms') {
-    margin: 0 0 #{-$_o-forms-spacing};
+    margin: #{-$_o-forms-group-item-spacing / 2} 0;
 
     input + .#{$class}__label {
         width: 100%; // We do not use display:block to maintain consistent margins (not collapsed).
         box-sizing: border-box;
-        margin: $_o-forms-checkbox-legend-spacing $_o-forms-checkbox-horizontal-spacing $_o-forms-spacing 0; // margins do not collapse, making the space between checkbox/radio inputs a little larger
+        margin: ($_o-forms-group-item-spacing / 2) $_o-forms-checkbox-horizontal-spacing ($_o-forms-group-item-spacing / 2) 0; // margins do not collapse, making the space between checkbox/radio inputs a little larger
         &:last-of-type {
             margin-right: 0;
         }

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -198,8 +198,10 @@
     position: relative;
     cursor: pointer;
     font-weight: oFontsWeight('normal');
-    padding-top: 2px; // To align the text with the center of the checkbox/radio
     user-select: none;
+    // To align the text with the center of the checkbox/radio
+    padding-top: 2px;
+    min-height: $_o-forms-radiocheckbox-default-size;
 }
 
 /// @access public

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -119,12 +119,15 @@
 /// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles to wrap a group of checkboxes or a group of radios for purposes of positioning etc.
 @mixin oFormsGroupContainer($class: 'o-forms') {
-    margin: #{$_o-forms-checkbox-legend-spacing - ($_o-forms-group-item-spacing / 2)} 0 #{-$_o-forms-group-item-spacing / 2} 0;
+    // Grouped elements may be displayed inline rather than stacked.
+    // As inline margins do not collapse.
+    $group-item-verticle-spacing: $_o-forms-group-spacing / 2;
+    margin: #{$_o-forms-checkbox-legend-spacing - $group-item-verticle-spacing} 0 #{-$group-item-verticle-spacing} 0;
 
     input + .#{$class}__label {
         width: 100%; // We do not use display:block to maintain consistent margins (not collapsed).
         box-sizing: border-box;
-        margin: ($_o-forms-group-item-spacing / 2) $_o-forms-checkbox-horizontal-spacing ($_o-forms-group-item-spacing / 2) 0; // margins do not collapse, making the space between checkbox/radio inputs a little larger
+        margin: $group-item-verticle-spacing $_o-forms-checkbox-horizontal-spacing $group-item-verticle-spacing 0;
         &:last-of-type {
             margin-right: 0;
         }

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -122,15 +122,12 @@
     // Grouped elements may be displayed inline rather than stacked.
     // As inline margins do not collapse.
     $group-item-verticle-spacing: $_o-forms-group-spacing / 2;
-    margin: #{$_o-forms-checkbox-legend-spacing - $group-item-verticle-spacing} 0 #{-$group-item-verticle-spacing} 0;
+    margin: #{$_o-forms-checkbox-legend-spacing - $group-item-verticle-spacing} #{-$_o-forms-checkbox-horizontal-spacing} #{-$group-item-verticle-spacing} 0;
 
     input + .#{$class}__label {
         width: 100%; // We do not use display:block to maintain consistent margins (not collapsed).
         box-sizing: border-box;
         margin: $group-item-verticle-spacing $_o-forms-checkbox-horizontal-spacing $group-item-verticle-spacing 0;
-        &:last-of-type {
-            margin-right: 0;
-        }
     }
 
     &--inline {
@@ -144,6 +141,9 @@
             display: inline-grid;
             grid-auto-columns: 1fr;
             grid-auto-flow: column;
+            overflow: hidden;
+            width: max-content;
+            max-width: 100%;
         }
         input + .#{$class}__label {
             margin-right: 0;
@@ -190,21 +190,25 @@
 @mixin oFormsRadioButtonsStyled($class: 'o-forms') {
     @include oBrandConfigureFor('o-forms') {
         @include oNormaliseVisuallyHidden;
-        $sidePadding: 32px;
+        $side-padding: 20px;
         & + .#{$class}__label {
             color: oBrandGet('radio-buttons-styled-text');
             cursor: pointer;
             font-size: $_o-forms-field-default-font-size;
             font-weight: oFontsWeight('semibold');
-            padding: 5px $sidePadding 7px;
+            padding: 5px $side-padding 7px;
             position: relative;
             text-align: center;
             transition: 0.3s background-color, 0.15s color ease-out;
             display: inline-block;
             border-left: 1px solid oBrandGet('radio-buttons-styled-border');
+            margin-top: 3px;
             &:first-of-type {
                 margin-left: 3px;
                 border-left: 0;
+            }
+            &:last-of-type {
+                margin-right: 3px;
             }
             &:before {
                 content: '';
@@ -244,7 +248,7 @@
             // Hack for odd border break with applied opacity.
             &:last-of-type {
                 left: -1px;
-                padding-left: $sidePadding + 1;
+                padding-left: $side-padding + 1;
                 position: relative;
             }
         }

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -119,7 +119,7 @@
 /// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles to wrap a group of checkboxes or a group of radios for purposes of positioning etc.
 @mixin oFormsGroupContainer($class: 'o-forms') {
-    margin: #{-$_o-forms-group-item-spacing / 2} 0;
+    margin: #{$_o-forms-checkbox-legend-spacing - ($_o-forms-group-item-spacing / 2)} 0 #{-$_o-forms-group-item-spacing / 2} 0;
 
     input + .#{$class}__label {
         width: 100%; // We do not use display:block to maintain consistent margins (not collapsed).

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -43,6 +43,9 @@
             @include oIconsGetIcon('tick', oBrandGet('checkbox-radio-checked-icon'), $_o-forms-radiocheckbox-default-size);
             background-color: oBrandGet('checkbox-radio-checked-background');
         }
+        & + .#{$class}__label::before {
+            background-color: oBrandGet('field-standard-background');
+        }
     }
 }
 
@@ -69,7 +72,6 @@
             border: 1px solid oBrandGet('field-standard-border');
             box-sizing: border-box;
             content: '';
-            background-color: oBrandGet('field-standard-background');
             transition: all 0.1s ease-in;
         }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -142,14 +142,14 @@
 
     // Inline radios/checkboxes.
     // Half inline margins as inline margins do not collapse.
-    $group-item-verticle-spacing: $_o-forms-group-spacing / 2;
+    $group-item-vertical-spacing: $_o-forms-group-spacing / 2;
     &--inline {
-        margin: #{-$group-item-verticle-spacing + $_o-forms-checkbox-legend-spacing} #{-$_o-forms-checkbox-horizontal-spacing} #{-$group-item-verticle-spacing} 0;
+        margin: #{-$group-item-vertical-spacing + $_o-forms-checkbox-legend-spacing} #{-$_o-forms-checkbox-horizontal-spacing} #{-$group-item-vertical-spacing} 0;
         .o-forms__toggle,
         input + .#{$class}__label {
             display: inline-block;
             width: auto;
-            margin: $group-item-verticle-spacing $_o-forms-checkbox-horizontal-spacing $group-item-verticle-spacing 0;
+            margin: $group-item-vertical-spacing $_o-forms-checkbox-horizontal-spacing $group-item-vertical-spacing 0;
         }
     }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -125,20 +125,19 @@
 
     // Stacked radios/checkboxes.
     // @breaking Remove the not selectors by removing the need to override label margins.
-    &:not(#{&}--inline-together):not(#{&}--inline) {
-        .o-forms__toggle,
-        input + .#{$class}__label {
-            display: block;
-            box-sizing: border-box;
-            margin: $_o-forms-group-spacing 0;
-            &:first-of-type {
-                margin-top: 0;
-            }
-            &:last-of-type {
-                margin-bottom: 0;
-            }
+    .o-forms__toggle,
+    input + .#{$class}__label {
+        display: block;
+        box-sizing: border-box;
+        margin: $_o-forms-group-spacing 0;
+        &:first-of-type {
+            margin-top: 0;
+        }
+        &:last-of-type {
+            margin-bottom: 0;
         }
     }
+
 
     // Inline radios/checkboxes.
     // Half inline margins as inline margins do not collapse.
@@ -150,6 +149,12 @@
             display: inline-block;
             width: auto;
             margin: $group-item-vertical-spacing $_o-forms-checkbox-horizontal-spacing $group-item-vertical-spacing 0;
+            &:first-of-type {
+                margin-top: $group-item-vertical-spacing;
+            }
+            &:last-of-type {
+                margin-bottom: $group-item-vertical-spacing;
+            }
         }
     }
 
@@ -164,7 +169,7 @@
             max-width: 100%;
         }
         input + .#{$class}__label {
-            margin-right: 0;
+            @include _oFormsRadioButtonsStyledMargin();
             width: auto;
             float: left; // Float to support non-grid browsers.
         }
@@ -212,6 +217,7 @@
         @include oNormaliseVisuallyHidden;
         $side-padding: 20px;
         & + .#{$class}__label {
+            @include _oFormsRadioButtonsStyledMargin();
             color: oBrandGet('radio-buttons-styled-text');
             cursor: pointer;
             font-size: $_o-forms-field-default-font-size;
@@ -273,6 +279,18 @@
                 position: relative;
             }
         }
+    }
+}
+
+/// Margins for styled button labels.
+/// @access private
+@mixin _oFormsRadioButtonsStyledMargin {
+    margin: 3px 0;
+    &:first-of-type {
+        margin: 3px 0 3px 3px;
+    }
+    &:last-of-type {
+        margin: 3px 3px 3px 0;
     }
 }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -125,18 +125,16 @@
 
     // Stacked radios/checkboxes.
     // @breaking Remove the not selectors by removing the need to override label margins.
-    &:not(#{&}--inline-together):not(#{&}--inline) {
-        .o-forms__toggle,
-        input + .#{$class}__label {
-            display: block;
-            box-sizing: border-box;
-            margin: $_o-forms-group-spacing 0;
-            &:first-of-type {
-                margin-top: 0;
-            }
-            &:last-of-type {
-                margin-bottom: 0;
-            }
+    .o-forms__toggle,
+    input + .#{$class}__label {
+        display: block;
+        box-sizing: border-box;
+        margin: $_o-forms-group-spacing 0;
+        &:first-of-type {
+            margin-top: 0;
+        }
+        &:last-of-type {
+            margin-bottom: 0;
         }
     }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -143,6 +143,7 @@
     $group-item-vertical-spacing: $_o-forms-group-spacing / 2;
     &--inline {
         margin: #{-$group-item-vertical-spacing + $_o-forms-checkbox-legend-spacing} #{-$_o-forms-checkbox-horizontal-spacing} #{-$group-item-vertical-spacing} 0;
+        max-width: 100%;
         .o-forms__toggle,
         input + .#{$class}__label {
             display: inline-block;

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -273,3 +273,18 @@
         }
     }
 }
+
+/// @access private
+/// @param {string} $class - The block level class name (BEM naming convention).
+/// @output Error styles for radio buttons.
+@mixin _oFormsRadioButtonsStyledInvalid($class: 'o-forms') {
+    @include oBrandConfigureFor('o-forms') {
+        & + .#{$class}__label {
+            &:first-of-type:before,
+            &:last-of-type:before,
+            &:before {
+                border-color: oBrandGet('field-invalid-border');
+            }
+        }
+    }
+}

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -119,23 +119,44 @@
 /// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles to wrap a group of checkboxes or a group of radios for purposes of positioning etc.
 @mixin oFormsGroupContainer($class: 'o-forms') {
-    // Grouped elements may be displayed inline rather than stacked.
-    // As inline margins do not collapse.
-    $group-item-verticle-spacing: $_o-forms-group-spacing / 2;
-    margin: #{$_o-forms-checkbox-legend-spacing - $group-item-verticle-spacing} #{-$_o-forms-checkbox-horizontal-spacing} #{-$group-item-verticle-spacing} 0;
+    margin-top: $_o-forms-checkbox-legend-spacing;
 
-    input + .#{$class}__label {
-        width: 100%; // We do not use display:block to maintain consistent margins (not collapsed).
-        box-sizing: border-box;
-        margin: $group-item-verticle-spacing $_o-forms-checkbox-horizontal-spacing $group-item-verticle-spacing 0;
-    }
-
-    &--inline {
+    // Stack grouped radios/checkboxes by default.
+    &:not(#{&}--inline-together){
+        .o-forms__toggle,
         input + .#{$class}__label {
-            width: auto;
+            display: block;
+            box-sizing: border-box;
+            margin: $_o-forms-group-spacing 0;
+            &:first-of-type {
+                margin-top: 0;
+            }
+            &:last-of-type {
+                margin-bottom: 0;
+            }
         }
     }
 
+    // Inline radios/checkboxes.
+    // Half inline margins as inline margins do not collapse.
+    $group-item-verticle-spacing: $_o-forms-group-spacing / 2;
+    &--inline {
+        margin: #{-$group-item-verticle-spacing + $_o-forms-checkbox-legend-spacing} #{-$_o-forms-checkbox-horizontal-spacing} #{-$group-item-verticle-spacing} 0;
+        .o-forms__toggle,
+        input + .#{$class}__label {
+            display: inline-block;
+            width: auto;
+            margin: $group-item-verticle-spacing $_o-forms-checkbox-horizontal-spacing $group-item-verticle-spacing 0;
+            &:first-of-type {
+                margin-top: $group-item-verticle-spacing;
+            }
+            &:last-of-type {
+                margin-bottom: $group-item-verticle-spacing;
+            }
+        }
+    }
+
+    // Styled radio buttons are grouped inline and close together.
     &--inline-together {
         @supports (display: grid) {
             display: inline-grid;
@@ -203,6 +224,7 @@
             display: inline-block;
             border-left: 1px solid oBrandGet('radio-buttons-styled-border');
             margin-top: 3px;
+            margin-bottom: 3px;
             &:first-of-type {
                 margin-left: 3px;
                 border-left: 0;

--- a/src/scss/mixins/suffix.scss
+++ b/src/scss/mixins/suffix.scss
@@ -28,6 +28,7 @@
 	display: table;
 	width: 100%;
 	box-sizing: border-box;
+	margin-top: $_o-forms-spacing;
 	.#{$class}__text,
 	.#{$class}__select,
 	.#{$class}__textarea {

--- a/src/scss/mixins/suffix.scss
+++ b/src/scss/mixins/suffix.scss
@@ -25,13 +25,12 @@
 /// @see {mixin} oFormsSuffix - Supports the o-form suffix feature.
 /// @output Wrapping styles to support an input suffix. This could be built upon to support a prefix.
 @mixin oFormsAffixWrapper($class: 'o-forms') {
-	@include oTypographyMargin($top: 2);
 	display: table;
 	width: 100%;
 	box-sizing: border-box;
 	.#{$class}__text,
 	.#{$class}__select,
 	.#{$class}__textarea {
-		@include oTypographyMargin($top: 0);
+		margin-top: 0;
 	}
 }


### PR DESCRIPTION
## Updates
1. Adds inline forms (IE9 falls back to stacked).
2. Updates styled radio button error state.
3. Reduces styled radio button padding. 
4. Removes white background from radio buttons.

## Notes to self (and the curious)
1. There are some mad selectors and specificity here -- feedback welcome. Inputs/input groups have unique margins between their label/legend, i.e. a group of checkboxes or radios are closer to their legend than styled radio buttons or text inputs are. This means the inputs/input groups own the margin (margin-top) rather than the labels/legends (margin-bottom). Input groups such as checkboxes may also have negative margins which enable their children to be inline within a stacked form. As the margins are unique and sometimes negative to support inline child elements it becomes problematic to remove the input/input group margin with a global inline form modifier. **Identifying the type of form input at the top most level e.g. `.o-forms.o-forms--textarea` might help increase flexibility and decrease specificity**, unfortunately requiring this would be a breaking.
2. IE10-11 Support grid but do not support @supports, so a browser hack has been used to only reset input margins if grid is supported or the browser is IE10/11.
3. Legends prevent `display: grid` (at least in many browsers),  [they establish a new block formatting context](https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements). This is why the inline container was added to wrap the legend contents with a css grid `legend.o-forms.o-forms--inline > .o-forms__inline-container`. If a legend is not being used however their is no need to use the inline container `div.o-forms.o-forms--inline`.

## Screenshots

**Styled radio buttons with reduced padding and  a new error state.**
![localhost_8999_demos_local_radios-button-styled html](https://user-images.githubusercontent.com/10405691/38734227-aaed25c0-3f1c-11e8-87d2-aea78aef0d25.png)

**Radios without a white background.**
![localhost_8999_demos_local_radios html](https://user-images.githubusercontent.com/10405691/38734250-c2e2810c-3f1c-11e8-9bd3-c350c8231bf8.png)

**Inline form in IE10**
![bs_win8_ie_10 0](https://user-images.githubusercontent.com/10405691/38734282-e24b3584-3f1c-11e8-93a3-922d6e3360d0.jpg)

**Inline form in Chrome**
![localhost_8999_demos_local_inline html 2](https://user-images.githubusercontent.com/10405691/38734293-efb7982a-3f1c-11e8-9c73-217ed9ac4c7d.png)
