### PR TITLE
Update vertical spacing.

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -30,11 +30,12 @@ $_o-forms-field-default-font-size: 14px;
 /// Spacing variables.
 /// @access private
 /// @type String
-$_o-forms-group-spacing: oTypographySpacingSize(5); // 20px
-$_o-forms-inline-group-spacing: oTypographySpacingSize(8); // 32px
 $_o-forms-spacing: oTypographySpacingSize(3); // 12px
-$_o-forms-checkbox-legend-spacing: oTypographySpacingSize(2); // 8px
+$_o-forms-section-spacing: oTypographySpacingSize(5); // 20px
+$_o-forms-inline-section-spacing: oTypographySpacingSize(8); // 32px
+$_o-forms-checkbox-legend-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-horizontal-spacing: 15px;
+$_o-forms-checkbox-vertical-spacing: oTypographySpacingSize(4); // 16px
 $_o-forms-padding: oGridGutter();
 
 /// Field dimention variables.

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -7,7 +7,7 @@
 @mixin oFormsGroup {
 	position: relative;
 	max-width: $_o-forms-field-max-width;
-	margin: 0 0 $_o-forms-group-spacing; // Reset top and side margins for fieldset usage
+	margin: 0 0 $_o-forms-section-spacing; // Reset top and side margins for fieldset usage
 	// reset <fieldset> defaults
 	padding: 0;
 	border: 0;
@@ -28,14 +28,14 @@
 	@include oGridRespondTo(S) {
 		@supports (display: grid) {
 			max-width: $_o-forms-inline-field-max-width;
-			margin: 0 0 $_o-forms-inline-group-spacing;
+			margin: 0 0 $_o-forms-inline-section-spacing;
 		}
 		// IE10-11 (no @supports but its own grid
 		// sass-lint:disable no-vendor-prefixes
 		&,
 		_:-ms-lang(x) {
 			max-width: $_o-forms-inline-field-max-width;
-			margin: 0 0 $_o-forms-inline-group-spacing;
+			margin: 0 0 $_o-forms-inline-section-spacing;
 		}
 		// sass-lint:enable no-vendor-prefixes
 	}

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -128,7 +128,7 @@
     input + .#{$class}__label {
         display: block;
         box-sizing: border-box;
-        margin: $_o-forms-group-spacing 0;
+        margin: $_o-forms-checkbox-vertical-spacing 0;
         &:first-of-type {
             margin-top: 0;
         }
@@ -140,7 +140,7 @@
 
     // Inline radios/checkboxes.
     // Half inline margins as inline margins do not collapse.
-    $group-item-vertical-spacing: $_o-forms-group-spacing / 2;
+    $group-item-vertical-spacing: $_o-forms-checkbox-vertical-spacing / 2;
     &--inline {
         margin: #{-$group-item-vertical-spacing + $_o-forms-checkbox-legend-spacing} #{-$_o-forms-checkbox-horizontal-spacing} #{-$group-item-vertical-spacing} 0;
         max-width: 100%;

--- a/src/scss/mixins/sections.scss
+++ b/src/scss/mixins/sections.scss
@@ -11,7 +11,7 @@
 		$message-selector: #{&}__message;
 		max-width: $_o-forms-field-max-width;
 		padding: $_o-forms-padding 0;
-		margin: 0 0 $_o-forms-group-spacing;
+		margin: 0 0 $_o-forms-section-spacing;
 		box-sizing: border-box;
 
 		@include oGridRespondTo(S) {


### PR DESCRIPTION
- Checkbox/radio groups now have a 12px margin from their legend (up from 8px).
- Checkboxes/radios within a group now have a 16px margin between one another (down drom 20px).

I've also renamed some variables to avoid confusion. Unfortunately we have a class `o-forms__group` which does not relate to `$_o-forms-group-spacing`.

`$_o-forms-group-spacing` is the space between instances of `o-forms` or [form sections](https://www.ft.com/__origami/service/build/v2/demos/o-forms@5.5.1/sections). I've renamed `$_o-forms-group-spacing` to `$_o-forms-section-spacing` and `$_o-forms-inline-group-spacing` to `$_o-forms-inline-section-spacing`.

before
<img width="426" alt="screen shot 2018-04-23 at 18 00 35" src="https://user-images.githubusercontent.com/10405691/39142159-ba8de4e4-4721-11e8-8252-5699e19aee36.png">

after
<img width="425" alt="screen shot 2018-04-23 at 18 05 34" src="https://user-images.githubusercontent.com/10405691/39142192-d2e9832c-4721-11e8-8f34-4e49eb1cfab8.png">
