### PR TITLE
Make stacking of inline elements on mobile optional.

### DIFF
--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -161,15 +161,22 @@
 
 /// @access public
 /// @param {string} $class - The block level class name (BEM naming convention).
+/// @param {Bool} $stack-on-small - On small devices inline elements stack. Set to false to keep inline elements inline at all times.
 /// @require {mixin} oFormsBaseFeatures - Basic form features must be output for inline modifiers to work.
 /// @output Styles to support inline forms, with labels/messaging to one side and inputs to the other.
-@mixin oFormsInlineFeature($class: 'o-forms') {
+@mixin oFormsInlineFeature($class: 'o-forms', $stack-on-small: true) {
 	.#{$class}--inline {
 		@include oFormsGroupInline($class);
 	}
 	.#{$class}--inline,
 	.#{$class}__inline-container {
-		@include oFormsGroupInlineContainer($class);
+		@if ($stack-on-small) {
+			@include oGridRespondTo(S) {
+				@include oFormsGroupInlineContainer($class);
+			}
+		} @else {
+			@include oFormsGroupInlineContainer($class);
+		}
 	}
 	.#{$class}--inline.#{$class}--radios,
 	.#{$class}--inline.#{$class}--checkboxes,

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -166,7 +166,7 @@
 /// @output Styles to support inline forms, with labels/messaging to one side and inputs to the other.
 @mixin oFormsInlineFeature($class: 'o-forms', $stack-on-small: true) {
 	.#{$class}--inline {
-		@include oFormsGroupInline($class);
+		@include oFormsGroupInline($class, $stack-on-small);
 	}
 	.#{$class}--inline,
 	.#{$class}__inline-container {

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -22,22 +22,31 @@
 }
 
 /// @access public
+/// @param {Bool} $stack-on-small - On small devices inline elements stack. Set to false to keep inline elements inline at all times.
 /// @require {mixin} oFormsGroup
 /// @output Styles to modify the o-forms/fieldset group for inline fields.
-@mixin oFormsGroupInline($class: 'o-forms') {
-	@include oGridRespondTo(S) {
-		@supports (display: grid) {
-			max-width: $_o-forms-inline-field-max-width;
+@mixin oFormsGroupInline($class: 'o-forms', $stack-on-small: true) {
+	@supports (display: grid) {
+		@include _oFormsGroupInlineStyles($stack-on-small);
+	}
+	// IE10-11 (no @supports but its own grid
+	// sass-lint:disable no-vendor-prefixes
+	&,
+	_:-ms-lang(x) {
+		@include _oFormsGroupInlineStyles($stack-on-small);
+	}
+	// sass-lint:enable no-vendor-prefixes
+}
+
+/// @access private
+@mixin _oFormsGroupInlineStyles($stack-on-small) {
+	max-width: $_o-forms-inline-field-max-width;
+	@if $stack-on-small {
+		@include oGridRespondTo(S) {
 			margin: 0 0 $_o-forms-inline-group-spacing;
 		}
-		// IE10-11 (no @supports but its own grid
-		// sass-lint:disable no-vendor-prefixes
-		&,
-		_:-ms-lang(x) {
-			max-width: $_o-forms-inline-field-max-width;
-			margin: 0 0 $_o-forms-inline-group-spacing;
-		}
-		// sass-lint:enable no-vendor-prefixes
+	} @else {
+		margin: 0 0 $_o-forms-inline-group-spacing;
 	}
 }
 

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -58,55 +58,53 @@
 /// @require {mixin} oFormsGroupInline
 /// @output Styles for the o-forms/fieldset inline container.
 @mixin oFormsGroupInlineContainer($class: 'o-forms') {
-	@include oGridRespondTo(S) {
-		// Fieldsets must use a container element, as fieldsets override the display vaule in some browsers.
-		// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-		// sass-lint:disable mixins-before-declarations no-vendor-prefixes
-		&:not(fieldset) {
-			display: grid;
-			grid-template-columns: repeat(2, 1fr);
-			grid-column-gap: 20px;
-			-ms-grid-columns: 1fr 20px 1fr;
-			min-width: 0;
+	// Fieldsets must use a container element, as fieldsets override the display vaule in some browsers.
+	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+	// sass-lint:disable mixins-before-declarations no-vendor-prefixes
+	&:not(fieldset) {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		grid-column-gap: 20px;
+		-ms-grid-columns: 1fr 20px 1fr;
+		min-width: 0;
 
-			@include _oFormsMessagingElementSelectors($class) {
-				grid-column: 1;
-				align-self: center;
+		@include _oFormsMessagingElementSelectors($class) {
+			grid-column: 1;
+			align-self: center;
+		}
+
+		// Explicitly position input elements in the css grid.
+		// IE10-11 do not support auto placement.
+		@include _oFormsInputElementSelectors($class) {
+			grid-column: 2;
+			-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+			grid-row: 1;
+			align-self: start; // IE10-11 defaults to stretch with align-items.
+			// Reset margins only if grid is supported.
+			@supports (display: grid) {
+				margin-top: 0;
 			}
-
-			// Explicitly position input elements in the css grid.
-			// IE10-11 do not support auto placement.
-			@include _oFormsInputElementSelectors($class) {
-				grid-column: 2;
-				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
-				grid-row: 1;
-				align-self: start; // IE10-11 defaults to stretch with align-items.
-				// Reset margins only if grid is supported.
-				@supports (display: grid) {
+			// Reset margins for IE10-11 (@supports unsupported).
+			@at-root {
+				&,
+				_:-ms-lang(x) {
 					margin-top: 0;
 				}
-				// Reset margins for IE10-11 (@supports unsupported).
-				@at-root {
-					&,
-					_:-ms-lang(x) {
-						margin-top: 0;
-					}
-				}
 			}
+		}
 
-			// Explicitly position error text in the css grid.
-			> .#{$class}__errortext {
-				grid-column: 2;
-				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
-				grid-row: 2;
-			}
+		// Explicitly position error text in the css grid.
+		> .#{$class}__errortext {
+			grid-column: 2;
+			-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+			grid-row: 2;
+		}
 
-			// For long labels and or additional text.
-			// Spans error text so the error text is against its input.
-			> .#{$class}__inline-item--long {
-				align-self: start;
-				grid-row: 1 / span 3;
-			}
+		// For long labels and or additional text.
+		// Spans error text so the error text is against its input.
+		> .#{$class}__inline-item--long {
+			align-self: start;
+			grid-row: 1 / span 3;
 		}
 	}
 	// sass-lint:enable mixins-before-declarations no-vendor-prefixes

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -137,7 +137,6 @@
         }
     }
 
-
     // Inline radios/checkboxes.
     // Half inline margins as inline margins do not collapse.
     $group-item-vertical-spacing: $_o-forms-group-spacing / 2;


### PR DESCRIPTION
Reviewing may be simpler to do by [ignoring the whitespace changes.](https://github.com/Financial-Times/o-forms/pull/210/files?w=1)