### PR TITLE
Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ If `o-forms` is used on a `fieldset` a wrapper `o-forms__inline-container` must 
 </fieldset>
 ```
 
+Using `o-forms--inline-controls` instead of `o-forms--inline` keeps the inputs inline even on mobile. It also expands the label forcing the inputs to align right. This is useful for long lists of simple styled radio buttons which are used as controls, e.g. repeated yes/no options. For an example see [the registry](https://www.ft.com/__origami/service/build/v2/demos/o-forms/inline-controls).
+
+```html
+<fieldset class="o-forms o-forms--inline-controls">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">Legend</legend>
+        <!-- styled radio button markup -->
+    </div>
+</fieldset>
+```
+
 Inline forms offer more options. For full demo markup see [inline examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/inline) on the Origami Registry.
 
 #### Additonal field information
@@ -341,6 +352,7 @@ Optional extras:
 - `oFormsSectionFeature` - Section support.
 - `oFormsSmallFeature` - Modifier styles for small text and select inputs.
 - `oFormsWideFeature` - Modifier styles for form elements with no width restriction.
+- `oFormsBleedFeature` - Modifier styles for form elements with no width restriction and no padding.
 
 For more details on specific mixins [browse the SassDoc documentation of the module](http://sassdoc.webservices.ft.com/v1/sassdoc/o-forms/#o-forms).
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If `o-forms` is used on a `fieldset` a wrapper `o-forms__inline-container` must 
 </fieldset>
 ```
 
-Using `o-forms--inline-controls` instead of `o-forms--inline` keeps the inputs inline even on mobile. It also expands the label forcing the inputs to align right. This is useful for long lists of simple styled radio buttons which are used as controls, e.g. repeated yes/no options. For an example see [the registry](https://www.ft.com/__origami/service/build/v2/demos/o-forms/inline-controls).
+Using `o-forms--inline-controls` instead of `o-forms--inline` keeps the inputs inline from mobile viewports upwards. It also expands the label forcing the inputs to align right. This is useful for long lists of simple styled radio buttons which are used as controls, e.g. repeated yes/no options. For an example see [the registry](https://www.ft.com/__origami/service/build/v2/demos/o-forms/inline-controls).
 
 ```html
 <fieldset class="o-forms o-forms--inline-controls">

--- a/demos/src/inline-controls.mustache
+++ b/demos/src/inline-controls.mustache
@@ -1,0 +1,36 @@
+<fieldset class="o-forms o-forms--inline-controls o-forms--bleed">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">Choice One</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="radio1" value="yes" class="o-forms__radio-button" id="radio10" />
+            <label for="radio41" class="o-forms__label">Yes</label>
+            <input type="radio" name="radio1" value="no" class="o-forms__radio-button" id="radio10" />
+            <label for="radio42" class="o-forms__label">No</label>
+        </div>
+    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline-controls o-forms--bleed o-forms--error">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">Choice Two</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="radio2" value="daily" class="o-forms__radio-button" id="radio20" />
+            <label for="radio41" class="o-forms__label">Yes</label>
+            <input type="radio" name="radio2" value="weekly" class="o-forms__radio-button" id="radio20" />
+            <label for="radio42" class="o-forms__label">No</label>
+        </div>
+        <div class="o-forms__errortext">Sorry your preference was not saved.</div>
+    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline-controls o-forms--bleed">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">Choice Three</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="radio1" value="yes" class="o-forms__radio-button" id="radio30" />
+            <label for="radio3" class="o-forms__label">Yes</label>
+            <input type="radio" name="radio1" value="no" class="o-forms__radio-button" id="radio30" />
+            <label for="radio3" class="o-forms__label">No</label>
+        </div>
+    </div>
+</fieldset>

--- a/demos/src/inline-controls.mustache
+++ b/demos/src/inline-controls.mustache
@@ -1,36 +1,36 @@
-<fieldset class="o-forms o-forms--inline-controls o-forms--bleed">
+<fieldset class="o-forms o-forms--inline-controls">
     <div class="o-forms__inline-container">
         <legend class="o-forms__label">Choice One</legend>
         <div class="o-forms__group o-forms__group--inline-together">
             <input type="radio" name="radio1" value="yes" class="o-forms__radio-button" id="radio10" />
-            <label for="radio41" class="o-forms__label">Yes</label>
-            <input type="radio" name="radio1" value="no" class="o-forms__radio-button" id="radio10" />
-            <label for="radio42" class="o-forms__label">No</label>
+            <label for="radio10" class="o-forms__label">Yes</label>
+            <input type="radio" name="radio1" value="no" class="o-forms__radio-button" id="radio11" />
+            <label for="radio11" class="o-forms__label">No</label>
         </div>
     </div>
 </fieldset>
 
-<fieldset class="o-forms o-forms--inline-controls o-forms--bleed o-forms--error">
+<fieldset class="o-forms o-forms--inline-controls o-forms--error">
     <div class="o-forms__inline-container">
         <legend class="o-forms__label">Choice Two</legend>
         <div class="o-forms__group o-forms__group--inline-together">
             <input type="radio" name="radio2" value="daily" class="o-forms__radio-button" id="radio20" />
-            <label for="radio41" class="o-forms__label">Yes</label>
-            <input type="radio" name="radio2" value="weekly" class="o-forms__radio-button" id="radio20" />
-            <label for="radio42" class="o-forms__label">No</label>
+            <label for="radio20" class="o-forms__label">Yes</label>
+            <input type="radio" name="radio2" value="weekly" class="o-forms__radio-button" id="radio21" />
+            <label for="radio21" class="o-forms__label">No</label>
         </div>
         <div class="o-forms__errortext">Sorry your preference was not saved.</div>
     </div>
 </fieldset>
 
-<fieldset class="o-forms o-forms--inline-controls o-forms--bleed">
+<fieldset class="o-forms o-forms--inline-controls">
     <div class="o-forms__inline-container">
         <legend class="o-forms__label">Choice Three</legend>
         <div class="o-forms__group o-forms__group--inline-together">
-            <input type="radio" name="radio1" value="yes" class="o-forms__radio-button" id="radio30" />
-            <label for="radio3" class="o-forms__label">Yes</label>
-            <input type="radio" name="radio1" value="no" class="o-forms__radio-button" id="radio30" />
-            <label for="radio3" class="o-forms__label">No</label>
+            <input type="radio" name="radio3" value="yes" class="o-forms__radio-button" id="radio30" />
+            <label for="radio30" class="o-forms__label">Yes</label>
+            <input type="radio" name="radio3" value="no" class="o-forms__radio-button" id="radio31" />
+            <label for="radio31" class="o-forms__label">No</label>
         </div>
     </div>
 </fieldset>

--- a/origami.json
+++ b/origami.json
@@ -75,6 +75,12 @@
 			"description": "Form elements may also be displayed inline."
 		},
 		{
+			"name": "inline-controls",
+			"title": "Inline Controls",
+			"template": "/demos/src/inline-controls.mustache",
+			"description": "For small controls of the same width E.g. repeated yes/no radios in a small container."
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "/demos/src/pa11y.mustache",

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -37,6 +37,7 @@ $_o-forms-checkbox-legend-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-horizontal-spacing: 15px;
 $_o-forms-checkbox-vertical-spacing: oTypographySpacingSize(4); // 16px
 $_o-forms-padding: oGridGutter();
+$_o-forms-default-error-text-margin: -1px;
 
 /// Field dimention variables.
 /// @access private

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -161,15 +161,22 @@
 
 /// @access public
 /// @param {string} $class - The block level class name (BEM naming convention).
+/// @param {Bool} $stack-on-small - On small devices inline elements stack. Set to false to keep inline elements inline at all times.
 /// @require {mixin} oFormsBaseFeatures - Basic form features must be output for inline modifiers to work.
 /// @output Styles to support inline forms, with labels/messaging to one side and inputs to the other.
-@mixin oFormsInlineFeature($class: 'o-forms') {
+@mixin oFormsInlineFeature($class: 'o-forms', $stack-on-small: true) {
 	.#{$class}--inline {
 		@include oFormsGroupInline($class);
 	}
 	.#{$class}--inline,
 	.#{$class}__inline-container {
-		@include oFormsGroupInlineContainer($class);
+		@if ($stack-on-small) {
+			@include oGridRespondTo(S) {
+				@include oFormsGroupInlineContainer($class);
+			}
+		} @else {
+			@include oFormsGroupInlineContainer($class);
+		}
 	}
 	.#{$class}--inline.#{$class}--radios,
 	.#{$class}--inline.#{$class}--checkboxes,

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -28,6 +28,8 @@
 	@include oFormsSmallFeature($class);
 	// Wide modifer.
 	@include oFormsWideFeature($class);
+	// Wide bleed.
+	@include oFormsBleedFeature($class);
 	// Unskin modifier.
 	@include oFormsUnskinFeature($class);
 }
@@ -161,27 +163,27 @@
 
 /// @access public
 /// @param {string} $class - The block level class name (BEM naming convention).
-/// @param {Bool} $stack-on-small - On small devices inline elements stack. Set to false to keep inline elements inline at all times.
 /// @require {mixin} oFormsBaseFeatures - Basic form features must be output for inline modifiers to work.
 /// @output Styles to support inline forms, with labels/messaging to one side and inputs to the other.
-@mixin oFormsInlineFeature($class: 'o-forms', $stack-on-small: true) {
-	.#{$class}--inline {
-		@include oFormsGroupInline($class, $stack-on-small);
-	}
+@mixin oFormsInlineFeature($class: 'o-forms') {
 	.#{$class}--inline,
+	.#{$class}--inline-controls {
+		@include oFormsGroupInline($class);
+	}
+	.#{$class}--inline:not(fieldset),
 	.#{$class}__inline-container {
-		@if ($stack-on-small) {
-			@include oGridRespondTo(S) {
-				@include oFormsGroupInlineContainer($class);
-			}
-		} @else {
+		@include oGridRespondTo(S) {
 			@include oFormsGroupInlineContainer($class);
 		}
 	}
+	.#{$class}--inline-controls > .#{$class}__inline-container {
+		@include oFormsGroupInlineContainer($class);
+		@include oFormsInlineControlsContainer($class);
+	}
 	.#{$class}--inline.#{$class}--radios,
 	.#{$class}--inline.#{$class}--checkboxes,
-	.#{$class}--radios .#{$class}__inline-container,
-	.#{$class}--checkboxes .#{$class}__inline-container {
+	.#{$class}--radios > .#{$class}__inline-container,
+	.#{$class}--checkboxes > .#{$class}__inline-container {
 		@include oFormsGroupInlineRadioCheckbox($class);
 	}
 }
@@ -192,11 +194,29 @@
 /// @output Modifying styles to make form inputs and any wrapping sections wide (removes max-width).
 @mixin oFormsWideFeature($class: 'o-forms') {
 	.#{$class}--wide,
+	.#{$class}--wide .#{$class}__inline-container,
 	.#{$class}--wide .#{$class}__text,
 	.#{$class}--wide .#{$class}__select,
 	.#{$class}--wide .#{$class}__textarea,
 	.#{$class}-section--wide {
 		max-width: none;
+	}
+}
+
+/// @access public
+/// @param {string} $class - The block level class name (BEM naming convention).
+/// @require {mixin} oFormsBaseFeatures - Basic form features must be output for wide modifiers to work.
+/// @output Modifying styles to make form inputs and any wrapping sections bleed (removes max-width and padding).
+@mixin oFormsBleedFeature($class: 'o-forms') {
+	.#{$class}--bleed,
+	.#{$class}--bleed .#{$class}__inline-container,
+	.#{$class}--bleed .#{$class}__text,
+	.#{$class}--bleed .#{$class}__select,
+	.#{$class}--bleed .#{$class}__textarea,
+	.#{$class}-section--bleed {
+		max-width: none;
+		padding-left: 0;
+		padding-right: 0;
 	}
 }
 

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -148,7 +148,7 @@
 	}
 	// Errors.
 	.#{$class}--error .#{$class}__radio-button {
-		@include _oFormsRadioButtonsStyledInvalid;
+		@include _oFormsRadioButtonsStyledInvalid($class);
 	}
 }
 

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -166,7 +166,7 @@
 /// @output Styles to support inline forms, with labels/messaging to one side and inputs to the other.
 @mixin oFormsInlineFeature($class: 'o-forms', $stack-on-small: true) {
 	.#{$class}--inline {
-		@include oFormsGroupInline($class);
+		@include oFormsGroupInline($class, $stack-on-small);
 	}
 	.#{$class}--inline,
 	.#{$class}__inline-container {

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -108,6 +108,10 @@
 	.#{$class}--error .#{$class}__group + .#{$class}__errortext {
 		@include _oFormsGroupContainerErrorText;
 	}
+	// Styled radio button validation.
+	.#{$class}--error .#{$class}__group--inline-together + .#{$class}__errortext {
+		margin-top: $_o-forms-default-error-text-margin;
+	}
 }
 
 /// @access public
@@ -166,8 +170,7 @@
 /// @require {mixin} oFormsBaseFeatures - Basic form features must be output for inline modifiers to work.
 /// @output Styles to support inline forms, with labels/messaging to one side and inputs to the other.
 @mixin oFormsInlineFeature($class: 'o-forms') {
-	.#{$class}--inline,
-	.#{$class}--inline-controls {
+	.#{$class}--inline {
 		@include oFormsGroupInline($class);
 	}
 	.#{$class}--inline:not(fieldset),
@@ -176,9 +179,8 @@
 			@include oFormsGroupInlineContainer($class);
 		}
 	}
-	.#{$class}--inline-controls > .#{$class}__inline-container {
-		@include oFormsGroupInlineContainer($class);
-		@include oFormsInlineControlsContainer($class);
+	.#{$class}--inline-controls {
+		@include oFormsGroupInlineControls($class);
 	}
 	.#{$class}--inline.#{$class}--radios,
 	.#{$class}--inline.#{$class}--checkboxes,

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -22,30 +22,25 @@
 }
 
 /// @access public
-/// @param {Bool} $stack-on-small - On small devices inline elements stack. Set to false to keep inline elements inline at all times.
 /// @require {mixin} oFormsGroup
 /// @output Styles to modify the o-forms/fieldset group for inline fields.
-@mixin oFormsGroupInline($class: 'o-forms', $stack-on-small: true) {
+@mixin oFormsGroupInline($class: 'o-forms') {
 	@supports (display: grid) {
-		@include _oFormsGroupInlineStyles($stack-on-small);
+		@include _oFormsGroupInlineStyles();
 	}
 	// IE10-11 (no @supports but its own grid
 	// sass-lint:disable no-vendor-prefixes
 	&,
 	_:-ms-lang(x) {
-		@include _oFormsGroupInlineStyles($stack-on-small);
+		@include _oFormsGroupInlineStyles();
 	}
 	// sass-lint:enable no-vendor-prefixes
 }
 
 /// @access private
-@mixin _oFormsGroupInlineStyles($stack-on-small) {
+@mixin _oFormsGroupInlineStyles() {
 	max-width: $_o-forms-inline-field-max-width;
-	@if $stack-on-small {
-		@include oGridRespondTo(S) {
-			margin: 0 0 $_o-forms-inline-section-spacing;
-		}
-	} @else {
+	@include oGridRespondTo(S) {
 		margin: 0 0 $_o-forms-inline-section-spacing;
 	}
 }
@@ -67,56 +62,60 @@
 /// @require {mixin} oFormsGroupInline
 /// @output Styles for the o-forms/fieldset inline container.
 @mixin oFormsGroupInlineContainer($class: 'o-forms') {
-	// Fieldsets must use a container element, as fieldsets override the display vaule in some browsers.
-	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
 	// sass-lint:disable mixins-before-declarations no-vendor-prefixes
-	&:not(fieldset) {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		grid-column-gap: 20px;
-		-ms-grid-columns: 1fr 20px 1fr;
-		min-width: 0;
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	grid-column-gap: 20px;
+	-ms-grid-columns: 1fr 20px 1fr;
+	min-width: 0;
 
-		@include _oFormsMessagingElementSelectors($class) {
-			grid-column: 1;
-			align-self: center;
+	@include _oFormsMessagingElementSelectors($class) {
+		grid-column: 1;
+		align-self: center;
+	}
+
+	// Explicitly position input elements in the css grid.
+	// IE10-11 do not support auto placement.
+	@include _oFormsInputElementSelectors($class) {
+		grid-column: 2;
+		-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+		grid-row: 1;
+		align-self: start; // IE10-11 defaults to stretch with align-items.
+		// Reset margins only if grid is supported.
+		@supports (display: grid) {
+			margin-top: 0;
 		}
-
-		// Explicitly position input elements in the css grid.
-		// IE10-11 do not support auto placement.
-		@include _oFormsInputElementSelectors($class) {
-			grid-column: 2;
-			-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
-			grid-row: 1;
-			align-self: start; // IE10-11 defaults to stretch with align-items.
-			// Reset margins only if grid is supported.
-			@supports (display: grid) {
+		// Reset margins for IE10-11 (@supports unsupported).
+		@at-root {
+			&,
+			_:-ms-lang(x) {
 				margin-top: 0;
 			}
-			// Reset margins for IE10-11 (@supports unsupported).
-			@at-root {
-				&,
-				_:-ms-lang(x) {
-					margin-top: 0;
-				}
-			}
-		}
-
-		// Explicitly position error text in the css grid.
-		> .#{$class}__errortext {
-			grid-column: 2;
-			-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
-			grid-row: 2;
-		}
-
-		// For long labels and or additional text.
-		// Spans error text so the error text is against its input.
-		> .#{$class}__inline-item--long {
-			align-self: start;
-			grid-row: 1 / span 3;
 		}
 	}
+
+	// Explicitly position error text in the css grid.
+	> .#{$class}__errortext {
+		grid-column: 2;
+		-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+		grid-row: 2;
+	}
+
+	// For long labels and or additional text.
+	// Spans error text so the error text is against its input.
+	> .#{$class}__inline-item--long {
+		align-self: start;
+		grid-row: 1 / span 3;
+	}
 	// sass-lint:enable mixins-before-declarations no-vendor-prefixes
+}
+
+/// @access public
+/// @require {mixin} oFormsGroup
+/// @require {mixin} oFormsGroupInline
+/// @output Modifys o-form--inline to suit small controls of the same width E.g. repeated yes/no radios in a narrow container.
+@mixin oFormsInlineControlsContainer($class: 'o-forms') {
+	grid-template-columns: 1fr min-content;
 }
 
 /// @access private

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -113,9 +113,12 @@
 /// @access public
 /// @require {mixin} oFormsGroup
 /// @require {mixin} oFormsGroupInline
-/// @output Modifys o-form--inline to suit small controls of the same width E.g. repeated yes/no radios in a narrow container.
-@mixin oFormsInlineControlsContainer($class: 'o-forms') {
-	grid-template-columns: 1fr min-content;
+/// @output Container for small controls of the same width E.g. repeated yes/no radios in a narrow container.
+@mixin oFormsGroupInlineControls($class: 'o-forms') {
+	&  > .#{$class}__inline-container {
+		@include oFormsGroupInlineContainer($class);
+		grid-template-columns: 1fr min-content;
+	}
 }
 
 /// @access private

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -22,22 +22,31 @@
 }
 
 /// @access public
+/// @param {Bool} $stack-on-small - On small devices inline elements stack. Set to false to keep inline elements inline at all times.
 /// @require {mixin} oFormsGroup
 /// @output Styles to modify the o-forms/fieldset group for inline fields.
-@mixin oFormsGroupInline($class: 'o-forms') {
-	@include oGridRespondTo(S) {
-		@supports (display: grid) {
-			max-width: $_o-forms-inline-field-max-width;
+@mixin oFormsGroupInline($class: 'o-forms', $stack-on-small: true) {
+	@supports (display: grid) {
+		@include _oFormsGroupInlineStyles($stack-on-small);
+	}
+	// IE10-11 (no @supports but its own grid
+	// sass-lint:disable no-vendor-prefixes
+	&,
+	_:-ms-lang(x) {
+		@include _oFormsGroupInlineStyles($stack-on-small);
+	}
+	// sass-lint:enable no-vendor-prefixes
+}
+
+/// @access private
+@mixin _oFormsGroupInlineStyles($stack-on-small) {
+	max-width: $_o-forms-inline-field-max-width;
+	@if $stack-on-small {
+		@include oGridRespondTo(S) {
 			margin: 0 0 $_o-forms-inline-group-spacing;
 		}
-		// IE10-11 (no @supports but its own grid
-		// sass-lint:disable no-vendor-prefixes
-		&,
-		_:-ms-lang(x) {
-			max-width: $_o-forms-inline-field-max-width;
-			margin: 0 0 $_o-forms-inline-group-spacing;
-		}
-		// sass-lint:enable no-vendor-prefixes
+	} @else {
+		margin: 0 0 $_o-forms-inline-group-spacing;
 	}
 }
 

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -58,55 +58,53 @@
 /// @require {mixin} oFormsGroupInline
 /// @output Styles for the o-forms/fieldset inline container.
 @mixin oFormsGroupInlineContainer($class: 'o-forms') {
-	@include oGridRespondTo(S) {
-		// Fieldsets must use a container element, as fieldsets override the display vaule in some browsers.
-		// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-		// sass-lint:disable mixins-before-declarations no-vendor-prefixes
-		&:not(fieldset) {
-			display: grid;
-			grid-template-columns: repeat(2, 1fr);
-			grid-column-gap: 20px;
-			-ms-grid-columns: 1fr 20px 1fr;
-			min-width: 0;
+	// Fieldsets must use a container element, as fieldsets override the display vaule in some browsers.
+	// https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+	// sass-lint:disable mixins-before-declarations no-vendor-prefixes
+	&:not(fieldset) {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		grid-column-gap: 20px;
+		-ms-grid-columns: 1fr 20px 1fr;
+		min-width: 0;
 
-			@include _oFormsMessagingElementSelectors($class) {
-				grid-column: 1;
-				align-self: center;
+		@include _oFormsMessagingElementSelectors($class) {
+			grid-column: 1;
+			align-self: center;
+		}
+
+		// Explicitly position input elements in the css grid.
+		// IE10-11 do not support auto placement.
+		@include _oFormsInputElementSelectors($class) {
+			grid-column: 2;
+			-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+			grid-row: 1;
+			align-self: start; // IE10-11 defaults to stretch with align-items.
+			// Reset margins only if grid is supported.
+			@supports (display: grid) {
+				margin-top: 0;
 			}
-
-			// Explicitly position input elements in the css grid.
-			// IE10-11 do not support auto placement.
-			@include _oFormsInputElementSelectors($class) {
-				grid-column: 2;
-				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
-				grid-row: 1;
-				align-self: start; // IE10-11 defaults to stretch with align-items.
-				// Reset margins only if grid is supported.
-				@supports (display: grid) {
+			// Reset margins for IE10-11 (@supports unsupported).
+			@at-root {
+				&,
+				_:-ms-lang(x) {
 					margin-top: 0;
 				}
-				// Reset margins for IE10-11 (@supports unsupported).
-				@at-root {
-					&,
-					_:-ms-lang(x) {
-						margin-top: 0;
-					}
-				}
 			}
+		}
 
-			// Explicitly position error text in the css grid.
-			> .#{$class}__errortext {
-				grid-column: 2;
-				-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
-				grid-row: 2;
-			}
+		// Explicitly position error text in the css grid.
+		> .#{$class}__errortext {
+			grid-column: 2;
+			-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+			grid-row: 2;
+		}
 
-			// For long labels and or additional text.
-			// Spans error text so the error text is against its input.
-			> .#{$class}__inline-item--long {
-				align-self: start;
-				grid-row: 1 / span 3;
-			}
+		// For long labels and or additional text.
+		// Spans error text so the error text is against its input.
+		> .#{$class}__inline-item--long {
+			align-self: start;
+			grid-row: 1 / span 3;
 		}
 	}
 	// sass-lint:enable mixins-before-declarations no-vendor-prefixes

--- a/src/scss/mixins/_labels.scss
+++ b/src/scss/mixins/_labels.scss
@@ -39,7 +39,7 @@
 		color: oBrandGet('field-invalid-text');
 		clear: both;
 		display: block;
-		margin-top: -1px;
+		margin-top: $_o-forms-default-error-text-margin;
 		padding: 3px 0;
 	}
 }

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -137,7 +137,6 @@
         }
     }
 
-
     // Inline radios/checkboxes.
     // Half inline margins as inline margins do not collapse.
     $group-item-vertical-spacing: $_o-forms-group-spacing / 2;


### PR DESCRIPTION
Review ignoring whitepace: https://github.com/Financial-Times/o-forms/pull/212/files?w=1

- Adds inline controls.
- Adds a `bleed` option to remove form padding.

E.g.
<img width="341" alt="screen shot 2018-04-24 at 17 58 08" src="https://user-images.githubusercontent.com/10405691/39202177-15a7f7a8-47e9-11e8-87b8-685f6b78eb24.png">

To achieve:
<img width="646" alt="screen shot 2018-04-24 at 17 58 49" src="https://user-images.githubusercontent.com/10405691/39202222-2edd2338-47e9-11e8-967c-62b0f4c3534c.png">
