### PR TITLE
Add form status

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,24 +283,6 @@ An error message, defined with `.o-forms__errortext`, can be appended to the con
 </div>
 ```
 
-#### Status
-
-To show a form is "saving" or is "saved" use a form status.
-
-To setup a form status, add the status element `.o-forms__status` within the contaning `.o-forms` element, with attributes `aria-hidden="true"` and `aria-live="true"`.
-
-To show a status add the status to the field's containing element `.o-forms--saving` or `.o-forms--saved` and update `aria-hidden` on the status element to `aria-hidden="false"`. The status is then read aloud by screen readers.
-
-```html
-<div class="o-forms o-forms--saving">
-	<label class="o-forms__label">Text input</label>
-	<input type="text" class="o-forms__text" />
-	<div class="o-forms__status" aria-hidden="false" aria-live="true"></div>
-</div>
-```
-
-[Status examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/status)
-
 #### Sections
 
 Wrap a group of `.o-forms` fields in a section `.o-forms-section` to highlight them and provide a global message.
@@ -441,6 +423,23 @@ Or you can set the `data-o-forms-apply-valid-state` attribute to true on the `<f
 	[...]
 </form>
 ```
+
+#### Status
+
+A form status is used to show an input is "saving" or is "saved". To show a status use the static method `updateInputStatus`.
+
+```js
+const OForms = require('o-forms');
+const formsInput = document.querySelector('input');
+
+OForms.updateInputStatus(formsInput, 'saving');
+```
+
+Valid statuses include "saving", "saved", or `null` to remove any current status.
+
+To add a left aligned status to an inline form input, add a placeholder status element `.o-forms__status .o-forms__status--left`, with attribute `aria-hidden="true"`, within the contaning `.o-forms` element.
+
+[Status examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/status)
 
 #### Listening to a toggle change
 Listening for the `oForms.toggled` event we can react to the status of a toggle checkbox. This event is fired when the toggle checkbox is clicked.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,24 @@ An error message, defined with `.o-forms__errortext`, can be appended to the con
 </div>
 ```
 
+#### Status
+
+To show a form is "saving" or is "saved" use a form status.
+
+To setup a form status, add the status element `.o-forms__status` within the contaning `.o-forms` element, with attributes `aria-hidden="true"` and `aria-live="true"`.
+
+To show a status add the status to the field's containing element `.o-forms--saving` or `.o-forms--saved` and update `aria-hidden` on the status element to `aria-hidden="false"`. The status is then read aloud by screen readers.
+
+```html
+<div class="o-forms o-forms--saving">
+	<label class="o-forms__label">Text input</label>
+	<input type="text" class="o-forms__text" />
+	<div class="o-forms__status" aria-hidden="false" aria-live="true"></div>
+</div>
+```
+
+[Status examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/status)
+
 #### Sections
 
 Wrap a group of `.o-forms` fields in a section `.o-forms-section` to highlight them and provide a global message.

--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ Optional extras:
 - `oFormsCheckboxToggleFeature` - Toggle support.
 - `oFormsSuffixFeature` - Suffix support.
 - `oFormsSectionFeature` - Section support.
+- `oFormsStatusFeature` - Styles for form status such as "saving" or "saved".
+- `oFormsInlineFeature` - Styles for inline forms.
 - `oFormsSmallFeature` - Modifier styles for small text and select inputs.
 - `oFormsWideFeature` - Modifier styles for form elements with no width restriction.
 - `oFormsBleedFeature` - Modifier styles for form elements with no width restriction and no padding.

--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "o-normalise": "^1.5.1",
     "o-typography": "^5.0.1",
     "o-icons": ">=4.0.0 <6",
-    "o-brand": "^2.0.2"
+    "o-brand": "^2.0.2",
+    "o-loading": "^2.2.1"
   }
 }

--- a/demos/src/inline-controls.mustache
+++ b/demos/src/inline-controls.mustache
@@ -22,16 +22,3 @@
         <div class="o-forms__errortext">Sorry there was a problem.</div>
     </div>
 </fieldset>
-
-<fieldset class="o-forms o-forms--saving o-forms--inline-controls">
-    <div class="o-forms__inline-container">
-        <legend class="o-forms__label">With Status</legend>
-        <div class="o-forms__group o-forms__group--inline-together">
-            <input type="radio" name="radio3" value="yes" class="o-forms__radio-button" id="radio30" />
-            <label for="radio30" class="o-forms__label">Yes</label>
-            <input type="radio" name="radio3" value="no" class="o-forms__radio-button" id="radio31" />
-            <label for="radio31" class="o-forms__label">No</label>
-        </div>
-        <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
-    </div>
-</fieldset>

--- a/demos/src/inline-controls.mustache
+++ b/demos/src/inline-controls.mustache
@@ -19,7 +19,7 @@
             <input type="radio" name="radio2" value="weekly" class="o-forms__radio-button" id="radio21" />
             <label for="radio21" class="o-forms__label">No</label>
         </div>
-        <div class="o-forms__errortext">Sorry your preference was not saved.</div>
+        <div class="o-forms__errortext">Sorry there was a problem.</div>
     </div>
 </fieldset>
 

--- a/demos/src/inline-controls.mustache
+++ b/demos/src/inline-controls.mustache
@@ -1,6 +1,6 @@
 <fieldset class="o-forms o-forms--inline-controls">
     <div class="o-forms__inline-container">
-        <legend class="o-forms__label">Choice One</legend>
+        <legend class="o-forms__label">Standard</legend>
         <div class="o-forms__group o-forms__group--inline-together">
             <input type="radio" name="radio1" value="yes" class="o-forms__radio-button" id="radio10" />
             <label for="radio10" class="o-forms__label">Yes</label>
@@ -12,7 +12,7 @@
 
 <fieldset class="o-forms o-forms--inline-controls o-forms--error">
     <div class="o-forms__inline-container">
-        <legend class="o-forms__label">Choice Two</legend>
+        <legend class="o-forms__label">With Error</legend>
         <div class="o-forms__group o-forms__group--inline-together">
             <input type="radio" name="radio2" value="daily" class="o-forms__radio-button" id="radio20" />
             <label for="radio20" class="o-forms__label">Yes</label>
@@ -23,14 +23,15 @@
     </div>
 </fieldset>
 
-<fieldset class="o-forms o-forms--inline-controls">
+<fieldset class="o-forms o-forms--saving o-forms--inline-controls">
     <div class="o-forms__inline-container">
-        <legend class="o-forms__label">Choice Three</legend>
+        <legend class="o-forms__label">With Status</legend>
         <div class="o-forms__group o-forms__group--inline-together">
             <input type="radio" name="radio3" value="yes" class="o-forms__radio-button" id="radio30" />
             <label for="radio30" class="o-forms__label">Yes</label>
             <input type="radio" name="radio3" value="no" class="o-forms__radio-button" id="radio31" />
             <label for="radio31" class="o-forms__label">No</label>
         </div>
+        <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
     </div>
 </fieldset>

--- a/demos/src/status.mustache
+++ b/demos/src/status.mustache
@@ -1,0 +1,62 @@
+<fieldset class="o-forms o-forms--saving" data-o-component="o-forms">
+    <legend class="o-forms__label">saving status</legend>
+    <div class="o-forms__group o-forms__group--inline-together">
+        <input type="radio" name="saving-stacked" value="daily" class="o-forms__radio-button" id="radio-saving-stacked-1" />
+        <label for="radio-saving-stacked-1" class="o-forms__label">Daily</label>
+        <input type="radio" name="saving-stacked" value="weekly" class="o-forms__radio-button" id="radio-saving-stacked-2" />
+        <label for="radio-saving-stacked-2" class="o-forms__label">Weekly</label>
+    </div>
+    <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline o-forms--saving" data-o-component="o-forms">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">inline saving status</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="saving" value="daily" class="o-forms__radio-button" id="radio-saving-1" />
+            <label for="radio-saving-1" class="o-forms__label">Daily</label>
+            <input type="radio" name="saving" value="weekly" class="o-forms__radio-button" id="radio-saving-2" />
+            <label for="radio-saving-2" class="o-forms__label">Weekly</label>
+        </div>
+        <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
+    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline o-forms--saved">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">inline saved status</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="saved" value="daily" class="o-forms__radio-button" id="radio-saved-1" />
+            <label for="radio-saved-1" class="o-forms__label">Daily</label>
+            <input type="radio" name="saved" value="weekly" class="o-forms__radio-button" id="radio-saved-2" />
+            <label for="radio-saved-2" class="o-forms__label">Weekly</label>
+        </div>
+        <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
+    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline o-forms--loading o-forms--saving" data-o-component="o-forms">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">icon only inline status</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="saving-icon" value="daily" class="o-forms__radio-button" id="radio-saving-icon-1" />
+            <label for="radio-saving-icon-1" class="o-forms__label">Daily</label>
+            <input type="radio" name="saving-icon" value="weekly" class="o-forms__radio-button" id="radio-saving-icon-2" />
+            <label for="radio-saving-icon-2" class="o-forms__label">Weekly</label>
+        </div>
+        <div class="o-forms__status o-forms__status--left o-forms__status--icon-only" aria-hidden="false" aria-live="true"></div>
+    </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--inline o-forms--saving">
+    <div class="o-forms__inline-container">
+        <legend class="o-forms__label">inline saving status (below)</legend>
+        <div class="o-forms__group o-forms__group--inline-together">
+            <input type="radio" name="below" value="daily" class="o-forms__radio-button" id="radio-status-below-1" />
+            <label for="radio-status-below-1" class="o-forms__label">Daily</label>
+            <input type="radio" name="below" value="weekly" class="o-forms__radio-button" id="radio-status-below-2" />
+            <label for="radio-status-below-2" class="o-forms__label">Weekly</label>
+        </div>
+        <div class="o-forms__status" aria-hidden="false" aria-live="true"></div>
+    </div>
+</fieldset>

--- a/main.scss
+++ b/main.scss
@@ -10,6 +10,7 @@
 @import "o-colors/main";
 @import "o-grid/main";
 @import "o-icons/main";
+@import "o-loading/main";
 
 // Deprecated form features.
 @import "src/scss/deprecated";

--- a/origami.json
+++ b/origami.json
@@ -81,6 +81,12 @@
 			"description": "For small controls of the same width E.g. repeated yes/no radios in a small container."
 		},
 		{
+			"name": "status",
+			"title": "Status",
+			"template": "/demos/src/status.mustache",
+			"description": "Feedback styles."
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "/demos/src/pa11y.mustache",

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -98,6 +98,7 @@ class Forms {
 		const oFormsEl = input.closest('.o-forms');
 		oFormsEl.classList.add('o-forms--error');
 		oFormsEl.classList.remove('o-forms--valid');
+		Forms.updateInputStatus(input, null); // Remove any form status e.g. "saving" or "saved".
 	}
 
 	handleInvalidEvent(event) {
@@ -132,6 +133,59 @@ class Forms {
 		this.opts = undefined;
 		this.validFormEls = undefined;
 		this.FormEl = undefined;
+	}
+
+	static updateInputStatus (input, status) {
+		if (!(input instanceof HTMLElement)) {
+			throw new TypeError(`Expecting \`${input}\` to be an instance of "HTMLElement".`);
+		}
+		const oFormsElSelector = '.o-forms';
+		const oFormsEl = input.closest(oFormsElSelector);
+		const oFormsElExists = (oFormsEl instanceof HTMLElement);
+		const validStatuses = [
+			'saving',
+			'saved'
+		];
+		// 1. Check the status can be updated.
+		// 1a. Validate the given status is `null` or one of the whitelisted values.
+		if (status && !validStatuses.includes(status)) {
+			throw new Error(`"${status}" is not a valid status for a form input.`);
+		}
+		// 1b. Confirm the form field element is found.
+		if (!oFormsElExists) {
+			console.warn(`Could not find form field element "${oFormsElSelector}" for the given input.`, input);
+			return false;
+		}
+		// 1c. Remove status if there is an error on the form field.
+		if (oFormsElExists && status && oFormsEl.classList.contains('o-forms--error')) {
+			console.warn(`Can not update the status of an input to "${status}" when the input has an active error. Removing status.`, input);
+			Forms.updateInputStatus(input, null);
+			return false;
+		}
+		// 2. Prepare status element.
+		// 2a. Create status element if one does not exist.
+		let statusElement = oFormsEl.querySelector(`.o-forms__status`);
+		if (!statusElement) {
+			statusElement = document.createElement("div");
+			statusElement.classList.add('o-forms__status');
+			oFormsEl.append(statusElement);
+		}
+		// 2b. Add aria-live attributes if not set.
+		if (!statusElement.hasAttribute('aria-live')) {
+			statusElement.setAttribute('aria-live', 'assertive');
+			statusElement.setAttribute('role', 'alert');
+		}
+		// 3. Remove existing status.
+		statusElement.setAttribute('aria-hidden', true);
+		validStatuses.forEach((status) => {
+			oFormsEl.classList.remove(`o-forms--${status}`);
+		});
+		// 4. Set the new status.
+		if (status) {
+			oFormsEl.classList.add(`o-forms--${status}`);
+			statusElement.setAttribute('aria-hidden', false);
+		}
+		return true;
 	}
 
 	static init (rootEl, opts) {

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -26,7 +26,6 @@ class Forms {
 			this.opts.applyValidState = declaredApplyValidState === 'true';
 		}
 
-
 		// o-forms should only be registered against a <form>
 		// element. If not, return to prevent errors
 		if (!(this.FormEl instanceof HTMLFormElement)) {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -33,6 +33,7 @@ $_o-forms-field-default-font-size: 14px;
 $_o-forms-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-section-spacing: oTypographySpacingSize(5); // 20px
 $_o-forms-inline-section-spacing: oTypographySpacingSize(8); // 32px
+$_o-forms-inline-control-with-error-section-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-legend-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-horizontal-spacing: 15px;
 $_o-forms-checkbox-vertical-spacing: oTypographySpacingSize(4); // 16px

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -37,7 +37,7 @@ $_o-forms-checkbox-legend-spacing: oTypographySpacingSize(3); // 12px
 $_o-forms-checkbox-horizontal-spacing: 15px;
 $_o-forms-checkbox-vertical-spacing: oTypographySpacingSize(4); // 16px
 $_o-forms-padding: oGridGutter();
-$_o-forms-default-error-text-margin: -1px;
+$_o-forms-default-error-text-margin: oTypographySpacingSize(1); // 4px;
 
 /// Field dimention variables.
 /// @access private

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -198,6 +198,11 @@
 /// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles for form status such as "saving" and "saved".
 @mixin oFormsStatusFeature($class: 'o-forms') {
+	// Icons align to a 40x40 pixel grid with 10px padding on each side.
+	// In this case however we want to remove that padding to align the icon flush with the input.
+	// https://github.com/Financial-Times/fticons/blob/master/contributing.md#design
+	$status-icon-size: $_o-forms-field-small-height;
+	$status-icon-padding: ($status-icon-size/40) * 10;
 	@include oBrandConfigureFor($component: 'o-forms') {
 		// Base status styles.
 		.#{$class}__status {
@@ -207,13 +212,13 @@
 			white-space: nowrap;
 			align-items: center;
 			min-width: 5em;
-			margin-top: 1px; // Aligns status with error text for seemless replacement.
 			@include oTypographySize($_o-forms-typography-scale-small);
 			&:after {
 				content: '';
 			}
 			&:before {
 				content: '';
+				margin: #{-$status-icon-padding} 0 #{-$status-icon-padding} #{-$status-icon-padding};
 			}
 		}
 
@@ -233,9 +238,9 @@
 				@include oLoadingSize('small');
 				@include oLoadingColor('dark');
 				// Reszise loader to match icon.
-				margin: 8px;
-				width: 8px;
-				height: 8px;
+				margin: 0 $status-icon-padding 0 0;
+				width: 10px;
+				height: 10px;
 				border-width: 2px;
 			}
 		}
@@ -247,13 +252,13 @@
 				color: oBrandGet('field-valid-text');
 			}
 			&:before {
-				@include oIconsGetIcon('tick', oBrandGet('field-valid-text'), $_o-forms-field-small-height);
+				@include oIconsGetIcon('tick', oBrandGet('field-valid-text'), $status-icon-size);
 			}
 		}
 
 		// Icon only statuses.
 		.#{$class} .#{$class}__status--icon-only {
-			min-width: $_o-forms-field-small-height;
+			min-width: $status-icon-size;
 			align-self: center;
 			&:after {
 				content: none;

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -206,13 +206,13 @@
 	@include oBrandConfigureFor($component: 'o-forms') {
 		// Base status styles.
 		.#{$class}__status {
+			@include oTypographySize($_o-forms-typography-scale-small);
 			opacity: 0;
 			visibility: hidden;
 			display: flex;
 			white-space: nowrap;
 			align-items: center;
 			min-width: 5em;
-			@include oTypographySize($_o-forms-typography-scale-small);
 			&:after {
 				content: '';
 			}

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -107,13 +107,13 @@
 		@include oFormsCheckbox($class);
 	}
 	// Checkbox and radio validation / status.
-	.#{$class}--error .#{$class}__group + .#{$class}__errortext,
-	.#{$class}__group + .#{$class}__status {
+	.#{$class}--error .#{$class}__group ~ .#{$class}__errortext,
+	.#{$class}__group ~ .#{$class}__status {
 		margin-top: $_o-forms-checkbox-legend-spacing;
 	}
 	// Styled radio button validation / status.
-	.#{$class}--error .#{$class}__group--inline-together + .#{$class}__errortext,
-	.#{$class}__group--inline-together + .#{$class}__status {
+	.#{$class}--error .#{$class}__group--inline-together ~ .#{$class}__errortext,
+	.#{$class}__group--inline-together ~ .#{$class}__status {
 		margin-top: $_o-forms-default-error-text-margin;
 	}
 }
@@ -207,12 +207,11 @@
 		// Base status styles.
 		.#{$class}__status {
 			@include oTypographySize($_o-forms-typography-scale-small);
-			opacity: 0;
-			visibility: hidden;
-			display: flex;
 			white-space: nowrap;
 			align-items: center;
 			min-width: 5em;
+			margin-top: $_o-forms-default-error-text-margin;
+			display: none;
 			&:after {
 				content: '';
 			}
@@ -224,8 +223,6 @@
 
 		.#{$class}__status[aria-hidden="false"] {
 			display: flex;
-			visibility: visible;
-			opacity: 1;
 		}
 
 		// Saving status.
@@ -261,7 +258,7 @@
 			min-width: $status-icon-size;
 			align-self: center;
 			&:after {
-				content: none;
+				@include oNormaliseVisuallyHidden;
 			}
 		}
 	}

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -22,6 +22,8 @@
 	@include oFormsCheckboxToggleFeature($class);
 	// Sections.
 	@include oFormsSectionFeature($class);
+	// Form statuses (eg. "saving", "saved").
+	@include oFormsStatusFeature($class);
 	// Inline Forms.
 	@include oFormsInlineFeature($class);
 	// Small modifer.
@@ -104,12 +106,14 @@
 	.#{$class}__checkbox {
 		@include oFormsCheckbox($class);
 	}
-	// Checkbox and radio validation.
-	.#{$class}--error .#{$class}__group + .#{$class}__errortext {
-		@include _oFormsGroupContainerErrorText;
+	// Checkbox and radio validation / status.
+	.#{$class}--error .#{$class}__group + .#{$class}__errortext,
+	.#{$class}__group + .#{$class}__status {
+		margin-top: $_o-forms-checkbox-legend-spacing;
 	}
-	// Styled radio button validation.
-	.#{$class}--error .#{$class}__group--inline-together + .#{$class}__errortext {
+	// Styled radio button validation / status.
+	.#{$class}--error .#{$class}__group--inline-together + .#{$class}__errortext,
+	.#{$class}__group--inline-together + .#{$class}__status {
 		margin-top: $_o-forms-default-error-text-margin;
 	}
 }
@@ -173,6 +177,7 @@
 	.#{$class}--inline {
 		@include oFormsGroupInline($class);
 	}
+
 	.#{$class}--inline:not(fieldset),
 	.#{$class}__inline-container {
 		@include oGridRespondTo(S) {
@@ -187,6 +192,73 @@
 	.#{$class}--radios > .#{$class}__inline-container,
 	.#{$class}--checkboxes > .#{$class}__inline-container {
 		@include oFormsGroupInlineRadioCheckbox($class);
+	}
+}
+/// @access public
+/// @param {string} $class - The block level class name (BEM naming convention).
+/// @output Styles for form status such as "saving" and "saved".
+@mixin oFormsStatusFeature($class: 'o-forms') {
+	@include oBrandConfigureFor($component: 'o-forms') {
+		// Base status styles.
+		.#{$class}__status {
+			opacity: 0;
+			visibility: hidden;
+			display: flex;
+			white-space: nowrap;
+			align-items: center;
+			min-width: 5em;
+			margin-top: 1px; // Aligns status with error text for seemless replacement.
+			@include oTypographySize($_o-forms-typography-scale-small);
+			&:after {
+				content: '';
+			}
+			&:before {
+				content: '';
+			}
+		}
+
+		.#{$class}__status[aria-hidden="false"] {
+			display: flex;
+			visibility: visible;
+			opacity: 1;
+		}
+
+		// Saving status.
+		.#{$class}--saving .#{$class}__status {
+			&:after {
+				content: 'Saving';
+			}
+			&:before {
+				@include oLoading();
+				@include oLoadingSize('small');
+				@include oLoadingColor('dark');
+				// Reszise loader to match icon.
+				margin: 8px;
+				width: 8px;
+				height: 8px;
+				border-width: 2px;
+			}
+		}
+
+		// Saved status.
+		.#{$class}--saved .#{$class}__status {
+			&:after {
+				content: 'Saved';
+				color: oBrandGet('field-valid-text');
+			}
+			&:before {
+				@include oIconsGetIcon('tick', oBrandGet('field-valid-text'), $_o-forms-field-small-height);
+			}
+		}
+
+		// Icon only statuses.
+		.#{$class} .#{$class}__status--icon-only {
+			min-width: $_o-forms-field-small-height;
+			align-self: center;
+			&:after {
+				content: none;
+			}
+		}
 	}
 }
 

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -63,11 +63,13 @@
 /// @output Styles for the o-forms/fieldset inline container.
 @mixin oFormsGroupInlineContainer($class: 'o-forms') {
 	// sass-lint:disable mixins-before-declarations no-vendor-prefixes
+	$grid-column-gap: 10px;
 	display: grid;
-	grid-template-columns: repeat(2, 1fr);
-	grid-column-gap: 20px;
-	-ms-grid-columns: 1fr 20px 1fr;
-	min-width: 0;
+	grid-template-columns: 1fr min-content 1fr;
+	grid-column-gap: $grid-column-gap;
+	-ms-grid-columns: 1fr $grid-column-gap min-content $grid-column-gap 1fr;
+	min-width: none;
+	align-items: baseline;
 
 	@include _oFormsMessagingElementSelectors($class) {
 		grid-column: 1;
@@ -77,10 +79,13 @@
 	// Explicitly position input elements in the css grid.
 	// IE10-11 do not support auto placement.
 	@include _oFormsInputElementSelectors($class) {
-		grid-column: 2;
-		-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+		grid-column: 3;
+		-ms-grid-column: 4; // IE10-11 has a fake column for a grid gap.
 		grid-row: 1;
 		align-self: start; // IE10-11 defaults to stretch with align-items.
+	}
+
+	@include _oFormsInputElementSelectors($class, $children-only: false) {
 		// Reset margins only if grid is supported.
 		@supports (display: grid) {
 			margin-top: 0;
@@ -94,10 +99,48 @@
 		}
 	}
 
-	// Explicitly position error text in the css grid.
-	> .#{$class}__errortext {
+	// Explicitly position status in the css grid.
+	.#{$class}__status {
+		grid-column: 3;
+		-ms-grid-column: 4; // IE10-11 has a fake column for a grid gap.
+		grid-row: 2;
+		justify-content: flex-start;
+		min-width: none;
+		align-self: center;
+		align-items: center;
+		&:after {
+			order: -1;
+		}
+		&:before {
+			order: -1;
+		}
+	}
+
+	.#{$class}__status--left {
 		grid-column: 2;
 		-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+		grid-row: 1;
+		justify-content: flex-end;
+		margin-top: 0px;
+	}
+
+	// If there is an error text di and status reposition the status.
+	@at-root {
+		.#{$class}--error .#{$class}__status {
+			display: none;
+		}
+	}
+
+	// Hack to display the status icon within the column gap.
+	.#{$class}__status--icon-only {
+		margin-right: -$grid-column-gap;
+		margin-left: $grid-column-gap;
+	}
+
+	// Explicitly position error text in the css grid.
+	> .#{$class}__errortext {
+		grid-column: 3;
+		-ms-grid-column: 4; // IE10-11 has a fake column for a grid gap.
 		grid-row: 2;
 	}
 
@@ -118,6 +161,9 @@
 	&  > .#{$class}__inline-container {
 		@include oFormsGroupInlineContainer($class);
 		grid-template-columns: 1fr min-content;
+		.#{$class}__group {
+			justify-self: end;
+		}
 	}
 }
 
@@ -133,13 +179,13 @@
 
 /// @access private
 /// @output A provided content block wrapped in selectors for form input elements / groups.
-@mixin _oFormsInputElementSelectors($class: 'o-forms') {
-	> .#{$class}__affix-wrapper,
-	> .#{$class}__text,
-	> .#{$class}__select,
-	> .#{$class}__textarea,
-	> .#{$class}__group,
-	> .#{$class}__inline-item--right {
+@mixin _oFormsInputElementSelectors($class: 'o-forms', $children-only: true) {
+	#{if($children-only, '>', '')} .#{$class}__affix-wrapper,
+	#{if($children-only, '>', '')} .#{$class}__text,
+	#{if($children-only, '>', '')} .#{$class}__select,
+	#{if($children-only, '>', '')} .#{$class}__textarea,
+	#{if($children-only, '>', '')} .#{$class}__group,
+	#{if($children-only, '>', '')} .#{$class}__inline-item--right {
 		@content;
 	}
 }

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -100,6 +100,12 @@
 	grid-row: 1;
 	justify-content: flex-end;
 	margin-top: 0px;
+	// Override `display: none` when inline and left to maintain status width.
+	display: flex;
+	visibility: hidden;
+	&[aria-hidden="false"] {
+		visibility: visible;
+	}
 }
 
 /// @access private
@@ -156,13 +162,6 @@
 		}
 		&:before {
 			order: -1;
-		}
-	}
-
-	// If there is an error text di and status reposition the status.
-	@at-root {
-		.#{$class}--error .#{$class}__status {
-			display: none;
 		}
 	}
 

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -86,6 +86,10 @@
 			}
 		}
 	}
+
+	&.#{$class}--error {
+		margin: 0 0 $_o-forms-inline-control-with-error-section-spacing;
+	}
 }
 
 /// @access private

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -62,6 +62,45 @@
 /// @require {mixin} oFormsGroupInline
 /// @output Styles for the o-forms/fieldset inline container.
 @mixin oFormsGroupInlineContainer($class: 'o-forms') {
+	@include _oFormsBaseInlineStyles($class);
+	.#{$class}__status--left {
+		@include _oFormsInlineStatusLeftStyles();
+	}
+}
+
+/// @access public
+/// @require {mixin} oFormsGroup
+/// @require {mixin} oFormsGroupInline
+/// @output Container for small controls of the same width E.g. repeated yes/no radios in a narrow container.
+@mixin oFormsGroupInlineControls($class: 'o-forms') {
+	&  > .#{$class}__inline-container {
+		@include _oFormsBaseInlineStyles($class);
+		grid-template-columns: 1fr min-content min-content;
+		.#{$class}__group {
+			justify-self: end;
+		}
+
+		@include oGridRespondTo(S) {
+			.#{$class}__status--left {
+				@include _oFormsInlineStatusLeftStyles();
+			}
+		}
+	}
+}
+
+/// @access private
+/// @output Styles to position form status (e.g. "saving") to the left of an input.
+@mixin _oFormsInlineStatusLeftStyles() {
+	grid-column: 2;
+	-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+	grid-row: 1;
+	justify-content: flex-end;
+	margin-top: 0px;
+}
+
+/// @access private
+/// @output Shared styles to make a form inline e.g. for for a generic inline form or inline controls.
+@mixin _oFormsBaseInlineStyles($class: 'o-forms') {
 	// sass-lint:disable mixins-before-declarations no-vendor-prefixes
 	$grid-column-gap: 10px;
 	display: grid;
@@ -116,14 +155,6 @@
 		}
 	}
 
-	.#{$class}__status--left {
-		grid-column: 2;
-		-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
-		grid-row: 1;
-		justify-content: flex-end;
-		margin-top: 0px;
-	}
-
 	// If there is an error text di and status reposition the status.
 	@at-root {
 		.#{$class}--error .#{$class}__status {
@@ -151,20 +182,6 @@
 		grid-row: 1 / span 3;
 	}
 	// sass-lint:enable mixins-before-declarations no-vendor-prefixes
-}
-
-/// @access public
-/// @require {mixin} oFormsGroup
-/// @require {mixin} oFormsGroupInline
-/// @output Container for small controls of the same width E.g. repeated yes/no radios in a narrow container.
-@mixin oFormsGroupInlineControls($class: 'o-forms') {
-	&  > .#{$class}__inline-container {
-		@include oFormsGroupInlineContainer($class);
-		grid-template-columns: 1fr min-content;
-		.#{$class}__group {
-			justify-self: end;
-		}
-	}
 }
 
 /// @access private

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -92,7 +92,7 @@
 /// @output Styles to position form status (e.g. "saving") to the left of an input.
 @mixin _oFormsInlineStatusLeftStyles() {
 	grid-column: 2;
-	-ms-grid-column: 3; // IE10-11 has a fake column for a grid gap.
+	-ms-grid-column: 3; // sass-lint:disable-line no-vendor-prefixes IE10-11 has a fake column for a grid gap.
 	grid-row: 1;
 	justify-content: flex-end;
 	margin-top: 0px;

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -129,7 +129,7 @@
 	// IE10-11 do not support auto placement.
 	@include _oFormsInputElementSelectors($class) {
 		grid-column: 3;
-		-ms-grid-column: 4; // IE10-11 has a fake column for a grid gap.
+		-ms-grid-column: 5; // IE10-11 has a fake column for a grid gap.
 		grid-row: 1;
 		align-self: start; // IE10-11 defaults to stretch with align-items.
 	}
@@ -151,7 +151,7 @@
 	// Explicitly position status in the css grid.
 	.#{$class}__status {
 		grid-column: 3;
-		-ms-grid-column: 4; // IE10-11 has a fake column for a grid gap.
+		-ms-grid-column: 5; // IE10-11 has a fake column for a grid gap.
 		grid-row: 2;
 		justify-content: flex-start;
 		min-width: none;
@@ -174,7 +174,7 @@
 	// Explicitly position error text in the css grid.
 	> .#{$class}__errortext {
 		grid-column: 3;
-		-ms-grid-column: 4; // IE10-11 has a fake column for a grid gap.
+		-ms-grid-column: 5; // IE10-11 has a fake column for a grid gap.
 		grid-row: 2;
 	}
 

--- a/src/scss/mixins/_labels.scss
+++ b/src/scss/mixins/_labels.scss
@@ -40,7 +40,6 @@
 		clear: both;
 		display: block;
 		margin-top: $_o-forms-default-error-text-margin;
-		padding: 3px 0;
 	}
 }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -187,13 +187,6 @@
 }
 
 /// @access private
-/// @require {mixin} oFormsErrorText - Foundation error text styles are required.
-/// @output Modifying styles to update the position of error text which pertains to a group.
-@mixin _oFormsGroupContainerErrorText {
-    margin-top: $_o-forms-checkbox-legend-spacing;
-}
-
-/// @access private
 /// @output Styles to modify checkbox/radio labels.
 @mixin _oFormsRadioCheckboxLabel {
     @include oTypographySize($_o-forms-typography-scale-regular);

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -319,6 +319,108 @@ describe("Forms", () => {
 		});
 	});
 
+	describe("update status method", () => {
+		it('adds a new status when a status element exists', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			const formStatusElement = document.querySelector('.o-forms__status');
+			// Add status.
+			const status = 'saving';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Confirm expected status classes and aria attributes.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${status}`));
+			proclaim.equal(formStatusElement.getAttribute(`aria-live`), 'assertive');
+			proclaim.equal(formStatusElement.getAttribute(`aria-hidden`), 'false');
+		});
+		it('creates a status element if one does not exist', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: false
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			const initialFormStatusElement = document.querySelector('.o-forms__status');
+			// Confirm no status exists.
+			proclaim.isNull(initialFormStatusElement, 'Expecting no form status element to exist yet.');
+			// Add status.
+			const status = 'saving';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Confirm form status element is created with the requested status.
+			const finalFormStatusElement = document.querySelector('.o-forms__status');
+			proclaim.ok(finalFormStatusElement, 'Expecting a form status element to have been created.');
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${status}`));
+		});
+		it('does not add a status if the form input has an active error', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				hasError: true
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			const formStatusElement = document.querySelector('.o-forms__status');
+			// Attempt to add status.
+			const status = 'saving';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Status is not added.
+			proclaim.isFalse(formFieldElement.classList.contains(`o-forms--${status}`), 'If a form field has an error it should not also have a status.');
+			proclaim.equal(formStatusElement.getAttribute(`aria-hidden`), 'true', 'If a form field has an error its status should be hidden.');
+		});
+		it('does not add an invalid status', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				hasError: true
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			// Attempt to add nonsense status.
+			const status = 'not-a-real-status';
+			const input = formFieldElement.querySelector('input');
+			// Status is not added.
+			proclaim.throws(() => {
+				Forms.updateInputStatus(input, status);
+			});
+		});
+		it('updates an existing status', () => {
+			const existingStatus = 'saving';
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				status: existingStatus
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			// Confirm their is an existing status to update.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${existingStatus}`), 'Expecting an existing form field status to test.');
+			// Attempt to update status.
+			const newStatus = 'saved';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, newStatus);
+			// Status is updated.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${newStatus}`));
+		});
+		it('removes an existing status if no status is given', () => {
+			const existingStatus = 'saving';
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				status: existingStatus
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			// Confirm their is an existing status to update.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${existingStatus}`), 'Expecting an existing form field status to test.');
+			// Attempt to remove status.
+			const status = null;
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Status is removed.
+			proclaim.isFalse(formFieldElement.classList.contains(`o-forms--${existingStatus}`));
+		});
+	});
+
 	describe("destroy method", () => {
 		it('destroys itself when not initialised on a <form> element', () => {
 			const html = `<form><input type="text" data-o-component="o-forms" /></form>`;

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -39,6 +39,18 @@ function htmlCode () {
 	insert(html);
 }
 
+function formFieldHtmlCode(opts) {
+	const html = `
+		<div class="o-forms ${opts && opts.hasError ? 'o-forms--error' : ''} ${opts && opts.status ? `o-forms--${opts.status}` : ''}">
+			<label for="o-forms-standard" class="o-forms__label">Text input</label>
+			<input type="text" id="required-input" class="o-forms__text" required pattern="valid"/>
+			${opts && opts.hasError ? '<div class="o-forms__errortext"></div>' : ''}
+			${opts && opts.includeStatusElement ? '<div class="o-forms__status"></div>' : ''}
+		</div>
+	`;
+	insert(html);
+}
+
 function allInputsHtmlCode () {
 	const html = `<div>
 		<form data-o-component="o-forms" id="element">
@@ -60,6 +72,7 @@ function allInputsHtmlCode () {
 
 export {
 	insert,
+	formFieldHtmlCode,
 	htmlCode,
 	allInputsHtmlCode,
 	reset


### PR DESCRIPTION
Adds the concept of a form status including "saving" and "saved".

![status](https://user-images.githubusercontent.com/10405691/39930052-9306c4e0-5531-11e8-82c4-7e5dc7385e84.gif)

<img width="509" alt="screen shot 2018-05-11 at 15 39 03" src="https://user-images.githubusercontent.com/10405691/39930062-99720e70-5531-11e8-9149-8aa1f430d9be.png">

Also works with inline controls:
<img width="441" alt="screen shot 2018-05-11 at 15 39 20" src="https://user-images.githubusercontent.com/10405691/39930070-9caba6a0-5531-11e8-8c4a-a0123e04b889.png">
