### PR TITLE
Form Status JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Or you can set the `data-o-forms-apply-valid-state` attribute to true on the `<f
 
 #### Status
 
-To show a form input is "saving" or is "saved" apply a form status using the static method `updateInputStatus`.
+A form status is used to show an input is "saving" or is "saved". To show a status use the static method `updateInputStatus`.
 
 ```js
 const OForms = require('o-forms');
@@ -436,6 +436,8 @@ OForms.updateInputStatus(formsInput, 'saving');
 ```
 
 Valid statuses include "saving", "saved", or `null` to remove any current status.
+
+To add a left aligned status to an inline form input, add a placeholder status element `.o-forms__status .o-forms__status--left`, with attribute `aria-hidden="true"`, within the contaning `.o-forms` element.
 
 [Status examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/status)
 

--- a/README.md
+++ b/README.md
@@ -283,24 +283,6 @@ An error message, defined with `.o-forms__errortext`, can be appended to the con
 </div>
 ```
 
-#### Status
-
-To show a form is "saving" or is "saved" use a form status.
-
-To setup a form status, add the status element `.o-forms__status` within the contaning `.o-forms` element, with attributes `aria-hidden="true"` and `aria-live="true"`.
-
-To show a status add the status to the field's containing element `.o-forms--saving` or `.o-forms--saved` and update `aria-hidden` on the status element to `aria-hidden="false"`. The status is then read aloud by screen readers.
-
-```html
-<div class="o-forms o-forms--saving">
-	<label class="o-forms__label">Text input</label>
-	<input type="text" class="o-forms__text" />
-	<div class="o-forms__status" aria-hidden="false" aria-live="true"></div>
-</div>
-```
-
-[Status examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/status)
-
 #### Sections
 
 Wrap a group of `.o-forms` fields in a section `.o-forms-section` to highlight them and provide a global message.
@@ -441,6 +423,21 @@ Or you can set the `data-o-forms-apply-valid-state` attribute to true on the `<f
 	[...]
 </form>
 ```
+
+#### Status
+
+To show a form input is "saving" or is "saved" apply a form status using the static method `updateInputStatus`.
+
+```js
+const OForms = require('o-forms');
+const formsInput = document.querySelector('input');
+
+OForms.updateInputStatus(formsInput, 'saving');
+```
+
+Valid statuses include "saving", "saved", or `null` to remove any current status.
+
+[Status examples](https://www.ft.com/__origami/service/build/v2/demos/o-forms/status)
 
 #### Listening to a toggle change
 Listening for the `oForms.toggled` event we can react to the status of a toggle checkbox. This event is fired when the toggle checkbox is clicked.

--- a/demos/src/inline-controls.mustache
+++ b/demos/src/inline-controls.mustache
@@ -22,16 +22,3 @@
         <div class="o-forms__errortext">Sorry there was a problem.</div>
     </div>
 </fieldset>
-
-<fieldset class="o-forms o-forms--saving o-forms--inline-controls">
-    <div class="o-forms__inline-container">
-        <legend class="o-forms__label">With Status</legend>
-        <div class="o-forms__group o-forms__group--inline-together">
-            <input type="radio" name="radio3" value="yes" class="o-forms__radio-button" id="radio30" />
-            <label for="radio30" class="o-forms__label">Yes</label>
-            <input type="radio" name="radio3" value="no" class="o-forms__radio-button" id="radio31" />
-            <label for="radio31" class="o-forms__label">No</label>
-        </div>
-        <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
-    </div>
-</fieldset>

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -98,6 +98,7 @@ class Forms {
 		const oFormsEl = input.closest('.o-forms');
 		oFormsEl.classList.add('o-forms--error');
 		oFormsEl.classList.remove('o-forms--valid');
+		Forms.updateInputStatus(input, null); // Remove any form status e.g. "saving" or "saved".
 	}
 
 	handleInvalidEvent(event) {
@@ -132,6 +133,58 @@ class Forms {
 		this.opts = undefined;
 		this.validFormEls = undefined;
 		this.FormEl = undefined;
+	}
+
+	static updateInputStatus (input, status) {
+		if (!input instanceof HTMLElement) {
+			throw new TypeError(`Expecting "input" to be an instance of "HTMLElement" but instead found ${oFormsEl instanceof HTMLElement}.`);
+		};
+		const oFormsElSelector = '.o-forms';
+		const oFormsEl = input.closest(oFormsElSelector);
+		const oFormsElExists = (oFormsEl instanceof HTMLElement);
+		const validStatuses = [
+			'saving',
+			'saved'
+		];
+		// 1. Check the status can be updated.
+		// 1a. Validate the given status is `null` or one of the whitelisted values.
+		if (status && !validStatuses.includes(status)) {
+			throw new Error(`"${status}" is not a valid status for a form input.`);
+		}
+		// 1b. Confirm the form field element is found.
+		if (!oFormsElExists) {
+			console.warn(`Could not find form field element "${oFormsElSelector}" for the given input.`, input);
+			return false;
+		}
+		// 1c. Confirm there is no error on the form field.
+		if (oFormsElExists && status && oFormsEl.classList.contains('o-forms--error')) {
+			console.warn(`Can not update the status of an input wth an active error. Status: ${status}.`, input);
+			return false;
+		}
+		// 2. Prepare status element.
+		// 2a. Create status element if one does not exist.
+		let statusElement = oFormsEl.querySelector(`.o-forms__status`);
+		if (!statusElement) {
+			statusElement = document.createElement("div");
+			statusElement.classList.add('o-forms__status');
+			oFormsEl.append(statusElement);
+		};
+		// 2b. Add aria-live attributes if not set.
+		if (!statusElement.hasAttribute('aria-live')) {
+			statusElement.setAttribute('aria-live', 'assertive');
+			statusElement.setAttribute('role', 'alert');
+		}
+		// 3. Remove existing status.
+		statusElement.setAttribute('aria-hidden', true);
+		validStatuses.forEach((status) => {
+			oFormsEl.classList.remove(`o-forms--${status}`);
+		});
+		// 4. Set the new status.
+		if (status) {
+			oFormsEl.classList.add(`o-forms--${status}`);
+			statusElement.setAttribute('aria-hidden', false);
+		};
+		return true;
 	}
 
 	static init (rootEl, opts) {

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -137,7 +137,7 @@ class Forms {
 
 	static updateInputStatus (input, status) {
 		if (!(input instanceof HTMLElement)) {
-			throw new TypeError(`Expecting "input" to be an instance of "HTMLElement" but instead found "${typeof oFormsEl}".`);
+			throw new TypeError(`Expecting \`${input}\` to be an instance of "HTMLElement".`);
 		}
 		const oFormsElSelector = '.o-forms';
 		const oFormsEl = input.closest(oFormsElSelector);

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -156,9 +156,10 @@ class Forms {
 			console.warn(`Could not find form field element "${oFormsElSelector}" for the given input.`, input);
 			return false;
 		}
-		// 1c. Confirm there is no error on the form field.
+		// 1c. Remove status if there is an error on the form field.
 		if (oFormsElExists && status && oFormsEl.classList.contains('o-forms--error')) {
-			console.warn(`Can not update the status of an input wth an active error. Status: ${status}.`, input);
+			console.warn(`Can not update the status of an input to "${status}" when the input has an active error. Removing status.`, input);
+			Forms.updateInputStatus(input, null);
 			return false;
 		}
 		// 2. Prepare status element.

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -137,7 +137,7 @@ class Forms {
 
 	static updateInputStatus (input, status) {
 		if (!(input instanceof HTMLElement)) {
-			throw new TypeError(`Expecting "input" to be an instance of "HTMLElement" but instead found ${oFormsEl instanceof HTMLElement}.`);
+			throw new TypeError(`Expecting "input" to be an instance of "HTMLElement" but instead found "${typeof oFormsEl}".`);
 		}
 		const oFormsElSelector = '.o-forms';
 		const oFormsEl = input.closest(oFormsElSelector);

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -136,9 +136,9 @@ class Forms {
 	}
 
 	static updateInputStatus (input, status) {
-		if (!input instanceof HTMLElement) {
+		if (!(input instanceof HTMLElement)) {
 			throw new TypeError(`Expecting "input" to be an instance of "HTMLElement" but instead found ${oFormsEl instanceof HTMLElement}.`);
-		};
+		}
 		const oFormsElSelector = '.o-forms';
 		const oFormsEl = input.closest(oFormsElSelector);
 		const oFormsElExists = (oFormsEl instanceof HTMLElement);
@@ -168,7 +168,7 @@ class Forms {
 			statusElement = document.createElement("div");
 			statusElement.classList.add('o-forms__status');
 			oFormsEl.append(statusElement);
-		};
+		}
 		// 2b. Add aria-live attributes if not set.
 		if (!statusElement.hasAttribute('aria-live')) {
 			statusElement.setAttribute('aria-live', 'assertive');
@@ -183,7 +183,7 @@ class Forms {
 		if (status) {
 			oFormsEl.classList.add(`o-forms--${status}`);
 			statusElement.setAttribute('aria-hidden', false);
-		};
+		}
 		return true;
 	}
 

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -107,13 +107,13 @@
 		@include oFormsCheckbox($class);
 	}
 	// Checkbox and radio validation / status.
-	.#{$class}--error .#{$class}__group + .#{$class}__errortext,
-	.#{$class}__group + .#{$class}__status {
+	.#{$class}--error .#{$class}__group ~ .#{$class}__errortext,
+	.#{$class}__group ~ .#{$class}__status {
 		margin-top: $_o-forms-checkbox-legend-spacing;
 	}
 	// Styled radio button validation / status.
-	.#{$class}--error .#{$class}__group--inline-together + .#{$class}__errortext,
-	.#{$class}__group--inline-together + .#{$class}__status {
+	.#{$class}--error .#{$class}__group--inline-together ~ .#{$class}__errortext,
+	.#{$class}__group--inline-together ~ .#{$class}__status {
 		margin-top: $_o-forms-default-error-text-margin;
 	}
 }
@@ -207,12 +207,11 @@
 		// Base status styles.
 		.#{$class}__status {
 			@include oTypographySize($_o-forms-typography-scale-small);
-			opacity: 0;
-			visibility: hidden;
-			display: flex;
 			white-space: nowrap;
 			align-items: center;
 			min-width: 5em;
+			margin-top: $_o-forms-default-error-text-margin;
+			display: none;
 			&:after {
 				content: '';
 			}
@@ -224,8 +223,6 @@
 
 		.#{$class}__status[aria-hidden="false"] {
 			display: flex;
-			visibility: visible;
-			opacity: 1;
 		}
 
 		// Saving status.
@@ -261,7 +258,7 @@
 			min-width: $status-icon-size;
 			align-self: center;
 			&:after {
-				content: none;
+				@include oNormaliseVisuallyHidden;
 			}
 		}
 	}

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -100,6 +100,12 @@
 	grid-row: 1;
 	justify-content: flex-end;
 	margin-top: 0px;
+	// Override `display: none` when inline and left to maintain status width.
+	display: flex;
+	visibility: hidden;
+	&[aria-hidden="false"] {
+		visibility: visible;
+	}
 }
 
 /// @access private
@@ -156,13 +162,6 @@
 		}
 		&:before {
 			order: -1;
-		}
-	}
-
-	// If there is an error text di and status reposition the status.
-	@at-root {
-		.#{$class}--error .#{$class}__status {
-			display: none;
 		}
 	}
 

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -319,6 +319,108 @@ describe("Forms", () => {
 		});
 	});
 
+	describe("update status method", () => {
+		it('adds a new status when a status element exists', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			const formStatusElement = document.querySelector('.o-forms__status');
+			// Add status.
+			const status = 'saving';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Confirm expected status classes and aria attributes.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${status}`));
+			proclaim.equal(formStatusElement.getAttribute(`aria-live`), 'assertive');
+			proclaim.equal(formStatusElement.getAttribute(`aria-hidden`), 'false');
+		});
+		it('creates a status element if one does not exist', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: false
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			const initialFormStatusElement = document.querySelector('.o-forms__status');
+			// Confirm no status exists.
+			proclaim.isNull(initialFormStatusElement, 'Expecting no form status element to exist yet.');
+			// Add status.
+			const status = 'saving';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Confirm form status element is created with the requested status.
+			const finalFormStatusElement = document.querySelector('.o-forms__status');
+			proclaim.ok(finalFormStatusElement, 'Expecting a form status element to have been created.');
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${status}`));
+		});
+		it('does not add a status if the form input has an active error', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				hasError: true
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			const formStatusElement = document.querySelector('.o-forms__status');
+			// Attempt to add status.
+			const status = 'saving';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Status is not added.
+			proclaim.isFalse(formFieldElement.classList.contains(`o-forms--${status}`), 'If a form field has an error it should not also have a status.');
+			proclaim.equal(formStatusElement.getAttribute(`aria-hidden`), 'true', 'If a form field has an error its status should be hidden.');
+		});
+		it('does not add an invalid status', () => {
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				hasError: true
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			// Attempt to add nonsense status.
+			const status = 'not-a-real-status';
+			const input = formFieldElement.querySelector('input');
+			// Status is not added.
+			proclaim.throws(() => {
+				Forms.updateInputStatus(input, status);
+			});
+		});
+		it('updates an existing status', () => {
+			const existingStatus = 'saving';
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				status: existingStatus
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			// Confirm their is an existing status to update.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${existingStatus}`), 'Expecting an existing form field status to test.');
+			// Attempt to update status.
+			const newStatus = 'saved';
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, newStatus);
+			// Status is updated.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${newStatus}`));
+		});
+		it('removes an existing status if no status is given', () => {
+			const existingStatus = 'saving';
+			fixtures.formFieldHtmlCode({
+				includeStatusElement: true,
+				status: existingStatus
+			});
+			// Get elements to test.
+			const formFieldElement = document.querySelector('.o-forms');
+			// Confirm their is an existing status to update.
+			proclaim.isTrue(formFieldElement.classList.contains(`o-forms--${existingStatus}`), 'Expecting an existing form field status to test.');
+			// Attempt to remove status.
+			const status = null;
+			const input = formFieldElement.querySelector('input');
+			Forms.updateInputStatus(input, status);
+			// Status is removed.
+			proclaim.isFalse(formFieldElement.classList.contains(`o-forms--${existingStatus}`));
+		});
+	});
+
 	describe("destroy method", () => {
 		it('destroys itself when not initialised on a <form> element', () => {
 			const html = `<form><input type="text" data-o-component="o-forms" /></form>`;

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -39,6 +39,18 @@ function htmlCode () {
 	insert(html);
 }
 
+function formFieldHtmlCode(opts) {
+	const html = `
+		<div class="o-forms ${opts && opts.hasError ? 'o-forms--error' : ''} ${opts && opts.status ? `o-forms--${opts.status}` : ''}">
+			<label for="o-forms-standard" class="o-forms__label">Text input</label>
+			<input type="text" id="required-input" class="o-forms__text" required pattern="valid"/>
+			${opts && opts.hasError ? '<div class="o-forms__errortext"></div>' : ''}
+			${opts && opts.includeStatusElement ? '<div class="o-forms__status"></div>' : ''}
+		</div>
+	`;
+	insert(html);
+}
+
 function allInputsHtmlCode () {
 	const html = `<div>
 		<form data-o-component="o-forms" id="element">
@@ -60,6 +72,7 @@ function allInputsHtmlCode () {
 
 export {
 	insert,
+	formFieldHtmlCode,
 	htmlCode,
 	allInputsHtmlCode,
 	reset


### PR DESCRIPTION
- Add a method to set form input status.
- Visually hide icon only statuses so screenreaders can read them.
- Set inactive statuses to `display: none` when not inline so they take no space