### PR TITLE
Make status sit within o-forms bottom margin.

### DIFF
--- a/demos/src/status.mustache
+++ b/demos/src/status.mustache
@@ -1,14 +1,3 @@
-<fieldset class="o-forms o-forms--saving" data-o-component="o-forms">
-    <legend class="o-forms__label">saving status</legend>
-    <div class="o-forms__group o-forms__group--inline-together">
-        <input type="radio" name="saving-stacked" value="daily" class="o-forms__radio-button" id="radio-saving-stacked-1" />
-        <label for="radio-saving-stacked-1" class="o-forms__label">Daily</label>
-        <input type="radio" name="saving-stacked" value="weekly" class="o-forms__radio-button" id="radio-saving-stacked-2" />
-        <label for="radio-saving-stacked-2" class="o-forms__label">Weekly</label>
-    </div>
-    <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
-</fieldset>
-
 <fieldset class="o-forms o-forms--inline o-forms--saving" data-o-component="o-forms">
     <div class="o-forms__inline-container">
         <legend class="o-forms__label">inline saving status</legend>
@@ -59,4 +48,15 @@
         </div>
         <div class="o-forms__status" aria-hidden="false" aria-live="true"></div>
     </div>
+</fieldset>
+
+<fieldset class="o-forms o-forms--saving" data-o-component="o-forms">
+    <legend class="o-forms__label">stacked saving status</legend>
+    <div class="o-forms__group o-forms__group--inline-together">
+        <input type="radio" name="saving-stacked" value="daily" class="o-forms__radio-button" id="radio-saving-stacked-1" />
+        <label for="radio-saving-stacked-1" class="o-forms__label">Daily</label>
+        <input type="radio" name="saving-stacked" value="weekly" class="o-forms__radio-button" id="radio-saving-stacked-2" />
+        <label for="radio-saving-stacked-2" class="o-forms__label">Weekly</label>
+    </div>
+    <div class="o-forms__status o-forms__status--left" aria-hidden="false" aria-live="true"></div>
 </fieldset>

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -207,6 +207,7 @@
 		// Base status styles.
 		.#{$class}__status {
 			@include oTypographySize($_o-forms-typography-scale-small);
+			line-height: 1em;
 			white-space: nowrap;
 			align-items: center;
 			min-width: 5em;
@@ -223,6 +224,8 @@
 
 		.#{$class}__status[aria-hidden="false"] {
 			display: flex;
+			// Sit within the margin of `.o-form` without pushing page content down.
+			margin-bottom: calc(-1em - #{$_o-forms-default-error-text-margin});
 		}
 
 		// Saving status.

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -105,6 +105,7 @@
 	visibility: hidden;
 	&[aria-hidden="false"] {
 		visibility: visible;
+		margin-bottom: 0px;
 	}
 }
 


### PR DESCRIPTION
So that setting a status does not push content down.
See issue: https://github.com/Financial-Times/o-forms/issues/219

![kapture 2018-06-01 at 12 17 13](https://user-images.githubusercontent.com/10405691/40838359-c4ffdf26-6595-11e8-9e5c-5fe6d86a2147.gif)
