### PR TITLE
Update styled radio buttons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ If your project does not need all `o-forms` features, you may reduce your projec
 Required:
 - `oFormsBaseFeatures` - Basic form features including `.o-forms`. Required by the other mixins.
 
-Optional extras:
+Optional features:
 - `oFormsRadioCheckboxFeatures` - Checkbox and radio support.
 - `oFormsRadioCheckboxRightModifier` - Modifier styles to align checkbox/radio inputs right.
 - `oFormsRadioButtonsStyledFeature` - Styled radio buttons support.
@@ -363,6 +363,10 @@ Optional extras:
 - `oFormsSmallFeature` - Modifier styles for small text and select inputs.
 - `oFormsWideFeature` - Modifier styles for form elements with no width restriction.
 - `oFormsBleedFeature` - Modifier styles for form elements with no width restriction and no padding.
+
+Customisation (see [SassDoc](http://sassdoc.webservices.ft.com/v1/sassdoc/o-forms/#o-forms)):
+- `oFormsRadioButtonsStyledTheme` - Used to customise the color of styled radio buttons.
+- `oFormsRadioButtonsStyledIcon` - Used to add an icon to styled radio buttons.
 
 For more details on specific mixins [browse the SassDoc documentation of the module](http://sassdoc.webservices.ft.com/v1/sassdoc/o-forms/#o-forms).
 

--- a/demos/src/anchor-radios-button-styling.mustache
+++ b/demos/src/anchor-radios-button-styling.mustache
@@ -1,0 +1,10 @@
+<div class="o-forms">
+    <div class="o-forms__group o-forms__group--inline-together">
+        <a href="#" class="o-forms__radio-button o-forms__radio-button--current">
+            Anchor Link A
+        </a>
+        <a href="#" class="o-forms__radio-button">
+            Anchor Link B
+        </a>
+    </div>
+</div>

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,0 +1,10 @@
+<div class="o-forms">
+    <div class="o-forms__group o-forms__group--inline-together">
+        <a href="#" class="o-forms__radio-button o-forms__radio-button--current o-forms__radio-button--custom-theme o-forms__radio-button--custom-grid-icon">
+            a
+        </a>
+        <a href="#" class="o-forms__radio-button o-forms__radio-button--custom-theme o-forms__radio-button--custom-list-icon">
+            b
+        </a>
+    </div>
+</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,6 +2,12 @@ $o-forms-is-silent: false;
 
 @import "../../main";
 
+$_o-forms-demo-theme: (
+	'checked-background': 'claret-50',
+	'border': 'black-30',
+	'negative-checked-background': 'claret-80',
+);
+
 html {
 	font-family: $o-forms-font-family;
 }
@@ -16,4 +22,16 @@ body {
 	margin-right: -#{oGridGutter()};
 	padding: oGridGutter();
 	background-color: oColorsGetPaletteColor('slate');
+}
+
+.o-forms__radio-button--custom-theme {
+	@include oFormsRadioButtonsStyledTheme($theme: $_o-forms-demo-theme);
+}
+
+.o-forms__radio-button--custom-list-icon {
+	@include oFormsRadioButtonsStyledIcon($icon-name: 'list', $theme: $_o-forms-demo-theme);
+}
+
+.o-forms__radio-button--custom-grid-icon {
+	@include oFormsRadioButtonsStyledIcon($icon-name: 'grid', $theme: $_o-forms-demo-theme);
 }

--- a/origami.json
+++ b/origami.json
@@ -47,7 +47,13 @@
 			"name": "radios-button-styled",
 			"title": "Radios with button styling",
 			"template": "/demos/src/radios-button-styling.mustache",
-			"description": "<strong>Usercase:</strong> Can be used to require the user to choose between alternatives, with no default set."
+			"description": "Usercase: Can be used to require the user to choose between alternatives, with no default set."
+		},
+		{
+			"name": "anchor-radios-button-styled",
+			"title": "Anchors with radio button styling",
+			"template": "/demos/src/anchor-radios-button-styling.mustache",
+			"description": "Where technically required anchor tags may also be used, outside a form, to achieve the styled radio button look."
 		},
 		{
 			"name": "checkboxes",
@@ -90,6 +96,13 @@
 			"title": "Status",
 			"template": "/demos/src/status.mustache",
 			"description": "Feedback styles."
+		},
+		{
+			"name": "custom",
+			"title": "Custom",
+			"template": "/demos/src/custom.mustache",
+			"hidden": true,
+			"description": "Custom styles."
 		},
 		{
 			"title": "Pa11y",

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -43,8 +43,8 @@ $_o-forms-default-error-text-margin: oTypographySpacingSize(1); // 4px;
 /// Field dimention variables.
 /// @access private
 /// @type String
-$_o-forms-field-default-height: 40px;  // align it to the big button size
-$_o-forms-field-small-height: 28px; // align it to the regular button size
+$_o-forms-field-default-height: 40px;  // align it to the big button size, @breaking see https://github.com/Financial-Times/o-forms/issues/224
+$_o-forms-field-small-height: 28px; // align it to the regular button size, @breaking see https://github.com/Financial-Times/o-forms/issues/224
 $_o-forms-field-max-width: 380px; // This is meant to be 1/3 of the columns in the full grid, should probably be using an o-grid function
 $_o-forms-inline-field-max-width: 470px; // 5/12 full grid width (5 cols)
 
@@ -67,11 +67,18 @@ $_o-forms-field-border-width: 1px;
 $_o-forms-field-border: $_o-forms-field-border-width solid _oFormsGet('field-standard-border');
 $_o-forms-field-border-radius: $o-normalise-border-radius;
 
-
 /// Radio input variables.
 /// @access private
 /// @type String
 $_o-forms-radiocheckbox-default-size: 24px; // Outer circle / box sizes
 $_o-forms-radio-internal-default-size: 12px; // Inner circle sizes
 
-
+/// Styled radio button input variables.
+/// @access private
+/// @type String | List
+$_o-forms-radio-styled-button-min-width: 60px; // Based on `o-buttons`, @breaking see https://github.com/Financial-Times/o-forms/issues/224
+$_o-forms-radio-styled-icon-size: 21px; // Based on `o-buttons`, @breaking see https://github.com/Financial-Times/o-forms/issues/224
+$_o-forms-radio-styled-padding: 6px; // Based on `o-buttons`, @breaking see https://github.com/Financial-Times/o-forms/issues/224
+$_o-forms-radio-styled-icon-padding: 22px; // Based on `o-buttons`, @breaking see https://github.com/Financial-Times/o-forms/issues/224
+$_o-forms-radio-styled-transition: 0.3s background-color, 0.15s color ease-out; // Based on `o-buttons`, @breaking see https://github.com/Financial-Times/o-forms/issues/224
+$_o-forms-radio-styled-button-gap: 3px;

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -203,7 +203,7 @@
     @at-root #{selector_unify(input, &)} {
         @include oNormaliseVisuallyHidden;
     }
-    @at-root #{selector_unify(a, &)},
+    @at-root a#{&},
     & + .#{$class}__label {
         @include _oFormsRadioButtonsStyledMargin();
         cursor: pointer;
@@ -239,12 +239,12 @@
             border-right: 0;
         }
     }
-    @at-root #{selector_unify(a, &)}:focus,
+    @at-root a#{&}:focus,
     &:focus + .#{$class}__label {
         @include oFormsCommonFieldFocus;
         z-index: 1;
     }
-    @at-root #{selector_unify(a, &)}:disabled,
+    @at-root a#{&}:disabled,
     &:disabled + .#{$class}__label {
         opacity: 0.5;
         cursor: default;
@@ -277,7 +277,7 @@
 @mixin oFormsRadioButtonsStyledTheme($class: 'o-forms', $theme: null) {
     $theme: _oFormsThemeToBrandVariants($theme);
     // Output theme
-    @at-root #{selector_unify(a, &)},
+    @at-root a#{&},
     & + .#{$class}__label {
         @include _oFormsRadioButtonsStyledMargin();
         color: _oFormsGet('radio-buttons-styled-text', $from: $theme);
@@ -295,16 +295,16 @@
         }
     }
     // sass-lint:disable space-after-colon
-    @at-root #{selector_unify(a, &)}:not(:disabled):not(.#{$class}__radio-button--current):hover,
+    @at-root a#{&}:not(:disabled):not(.#{$class}__radio-button--current):hover,
     &:not(:disabled):not(:checked) + .#{$class}__label:hover {
         background-color: rgba(_oFormsGet('checkbox-radio-hover-background', $from: $theme), 0.15);
     }
-    @at-root #{selector_unify(a, &)}.#{$class}__radio-button--current,
+    @at-root a#{&}.#{$class}__radio-button--current,
     &:checked + .#{$class}__label {
         background-color: _oFormsGet('radio-buttons-styled-checked-background', $from: $theme);
         color: _oFormsGet('radio-buttons-styled-checked-text', $from: $theme);
     }
-    @at-root #{selector_unify(a, &)}.#{$class}__radio-button--negative.#{$class}__radio-button--current,
+    @at-root a#{&}.#{$class}__radio-button--negative.#{$class}__radio-button--current,
     &--negative:checked + .#{$class}__label {
         background-color: _oFormsGet('radio-buttons-styled-negative-checked-background', $from: $theme);
     }
@@ -325,7 +325,7 @@
 /// @output An icon for styled radio buttons.
 @mixin oFormsRadioButtonsStyledIcon($icon-name, $theme: null, $class: 'o-forms') {
     $theme: _oFormsThemeToBrandVariants($theme);
-    @at-root #{selector_unify(a, &)},
+    @at-root a#{&},
     & + .#{$class}__label {
         @include oIconsGetIcon(
             $icon-name: $icon-name,
@@ -354,7 +354,7 @@
             display: none;
         }
     }
-    @at-root #{selector_unify(a, &)}.#{$class}__radio-button--current,
+    @at-root a#{&}.#{$class}__radio-button--current,
     &:checked + .#{$class}__label {
         @include oIconsGetIcon(
             $icon-name: $icon-name,

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -261,7 +261,7 @@
 
 /// @access public
 /// @example
-/// .o-forms__my-custom-radio-button {
+/// .o-forms__radio-button--custom {
 ///     @include oFormsRadioButtonsStyledTheme($theme: (
 ///         'checked-background': 'claret-80',
 ///         'negative-checked-background': 'claret-30',

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -200,7 +200,7 @@
 /// @output Styles for radios which look like a group of buttons, where one can be selected.
 @mixin oFormsRadioButtonsStyled($class: 'o-forms') {
     // Output base radio button styles.
-    @at-root #{selector_unify(input, &)} {
+    @at-root input#{&} {
         @include oNormaliseVisuallyHidden;
     }
     @at-root a#{&},

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -312,7 +312,7 @@
 }
 
 /// @access public
-/// @example - Adding an icon with a custom theme, 'negative-checked-background' is optional.
+/// @example scss - Adding an icon with a custom theme (optional). If a custom theme is passed, 'negative-checked-background' is optional.
 /// .o-forms__radio-button--my-custom-icon {
 /// 	@include oFormsRadioButtonsStyledIcon($icon-name: 'grid', $theme: (
 /// 		'checked-background': 'claret-50',
@@ -321,7 +321,7 @@
 /// 	));
 /// }
 /// @param {string} $class - The block level class name (BEM naming convention).
-/// @param {map|null} $theme - A custom theme map. See oFormsRadioButtonsStyledTheme (optional).
+/// @param {map|null} $theme - A custom theme map (optional, see example).
 /// @output An icon for styled radio buttons.
 @mixin oFormsRadioButtonsStyledIcon($icon-name, $theme: null, $class: 'o-forms') {
     $theme: _oFormsThemeToBrandVariants($theme);

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -199,82 +199,212 @@
 /// @param {string} $class - The block level class name (BEM naming convention).
 /// @output Styles for radios which look like a group of buttons, where one can be selected.
 @mixin oFormsRadioButtonsStyled($class: 'o-forms') {
-    @include oNormaliseVisuallyHidden;
-    $side-padding: 20px;
+    // Output base radio button styles.
+    @at-root #{selector_unify(input, &)} {
+        @include oNormaliseVisuallyHidden;
+    }
+    @at-root #{selector_unify(a, &)},
     & + .#{$class}__label {
         @include _oFormsRadioButtonsStyledMargin();
-        color: _oFormsGet('radio-buttons-styled-text');
         cursor: pointer;
         font-size: $_o-forms-field-default-font-size;
+        line-height: $_o-forms-field-default-font-size;
         font-weight: oFontsWeight('semibold');
-        padding: 5px $side-padding 7px;
+        padding: $_o-forms-radio-styled-padding;
+        min-height: $_o-forms-field-small-height;
+        min-width: $_o-forms-radio-styled-button-min-width - $_o-forms-radio-styled-button-gap;
+        box-sizing: border-box;
         position: relative;
         text-align: center;
-        transition: 0.3s background-color, 0.15s color ease-out;
+        text-decoration: none;
+        transition: $_o-forms-radio-styled-transition;
         display: inline-block;
-        border-left: 1px solid _oFormsGet('radio-buttons-styled-border');
-        margin-top: 3px;
-        margin-bottom: 3px;
+        margin-top: $_o-forms-radio-styled-button-gap;
+        margin-bottom: $_o-forms-radio-styled-button-gap;
         &:first-of-type {
-            margin-left: 3px;
+            margin-left: $_o-forms-radio-styled-button-gap;
             border-left: 0;
         }
         &:last-of-type {
-            margin-right: 3px;
+            margin-right: $_o-forms-radio-styled-button-gap;
         }
         &:before {
             content: '';
             position: absolute;
-            top: -3px;
-            right: -3px;
-            bottom: -3px;
-            left: -3px;
-            border: 1px solid _oFormsGet('radio-buttons-styled-border');
+            top: -$_o-forms-radio-styled-button-gap;
+            right: -$_o-forms-radio-styled-button-gap;
+            bottom: -$_o-forms-radio-styled-button-gap;
+            left: -$_o-forms-radio-styled-button-gap;
             border-left: 0;
             border-right: 0;
         }
-        &:last-of-type:before {
-            border-right: 1px solid _oFormsGet('radio-buttons-styled-border');
-        }
-        &:first-of-type:before {
-            border-left: 1px solid _oFormsGet('radio-buttons-styled-border');
-        }
     }
-    &:not(:disabled):not(:checked) + .#{$class}__label:hover {
-        background-color: rgba(_oFormsGet('checkbox-radio-hover-background'), 0.15);
-    }
-    &:checked + .#{$class}__label {
-        background-color: _oFormsGet('radio-buttons-styled-checked-background');
-        color: _oFormsGet('radio-buttons-styled-checked-text');
-    }
-    &--negative:checked + .#{$class}__label {
-            background-color: _oFormsGet('radio-buttons-styled-negative-checked-background');
-    }
+    @at-root #{selector_unify(a, &)}:focus,
     &:focus + .#{$class}__label {
         @include oFormsCommonFieldFocus;
         z-index: 1;
     }
+    @at-root #{selector_unify(a, &)}:disabled,
     &:disabled + .#{$class}__label {
         opacity: 0.5;
         cursor: default;
         // Hack for odd border break with applied opacity.
         &:last-of-type {
             left: -1px;
-            padding-left: $side-padding + 1;
+            padding-left: $_o-forms-radio-styled-padding + 1;
             position: relative;
         }
     }
+    // Output styles for the default radio button theme.
+    @include oFormsRadioButtonsStyledTheme($class);
+}
+
+/// @access public
+/// @example
+/// .o-forms__my-custom-radio-button {
+///     @include oFormsRadioButtonsStyledTheme($theme: (
+///         'checked-background': 'claret-80',
+///         'negative-checked-background': 'claret-30',
+///         'border': 'black-30'
+///     ));
+/// }
+/// @param {string} $class - The block level class name (BEM naming convention).
+/// @param {map|null} $class - A custom theme map.
+/// @prop {string} $class.checked-background - An Origami color name e.g. "teal-50".
+/// @prop {string} $class.border - An Origami color name for the border e.g. "black-30".
+/// @prop {string} $class.negative-checked-background [$theme.checked-background] - An Origami color for negative choice radio buttons (optional).
+/// @output Modifying theme styles for styled radio buttons.
+@mixin oFormsRadioButtonsStyledTheme($class: 'o-forms', $theme: null) {
+    $theme: _oFormsThemeToBrandVariants($theme);
+    // Output theme
+    @at-root #{selector_unify(a, &)},
+    & + .#{$class}__label {
+        @include _oFormsRadioButtonsStyledMargin();
+        color: _oFormsGet('radio-buttons-styled-text', $from: $theme);
+        border-left: 1px solid _oFormsGet('radio-buttons-styled-border', $from: $theme);
+        &:before {
+            border: 1px solid _oFormsGet('radio-buttons-styled-border', $from: $theme);
+            border-left: 0;
+            border-right: 0;
+        }
+        &:last-of-type:before {
+            border-right: 1px solid _oFormsGet('radio-buttons-styled-border', $from: $theme);
+        }
+        &:first-of-type:before {
+            border-left: 1px solid _oFormsGet('radio-buttons-styled-border', $from: $theme);
+        }
+    }
+    @at-root #{selector_unify(a, &)}:not(:disabled):not(.#{$class}__radio-button--current):hover,
+    &:not(:disabled):not(:checked) + .#{$class}__label:hover {
+        background-color: rgba(_oFormsGet('checkbox-radio-hover-background', $from: $theme), 0.15);
+    }
+    @at-root #{selector_unify(a, &)}.#{$class}__radio-button--current,
+    &:checked + .#{$class}__label {
+        background-color: _oFormsGet('radio-buttons-styled-checked-background', $from: $theme);
+        color: _oFormsGet('radio-buttons-styled-checked-text', $from: $theme);
+    }
+    @at-root #{selector_unify(a, &)}.#{$class}__radio-button--negative.#{$class}__radio-button--current,
+    &--negative:checked + .#{$class}__label {
+        background-color: _oFormsGet('radio-buttons-styled-negative-checked-background', $from: $theme);
+    }
+}
+
+/// @access public
+/// @example
+/// .o-forms__radio-button--custom-grid-icon {
+/// 	@include oFormsRadioButtonsStyledIcon($icon-name: 'grid', $theme: (
+/// 		'checked-background': 'claret-50',
+/// 		'border': 'black-30',
+/// 		'negative-checked-background': 'claret-80',
+/// 	));
+/// }
+/// @param {string} $class - The block level class name (BEM naming convention).
+/// @param {map|null} $theme - A custom theme map. See oFormsRadioButtonsStyledTheme (optional).
+/// @output An icon for styled radio buttons.
+@mixin oFormsRadioButtonsStyledIcon($icon-name, $theme: null, $class: 'o-forms') {
+    $theme: _oFormsThemeToBrandVariants($theme);
+    @at-root #{selector_unify(a, &)},
+    & + .#{$class}__label {
+        @include oIconsGetIcon(
+            $icon-name: $icon-name,
+            $apply-base-styles: false,
+            $apply-width-height: false,
+            $color: _oFormsGet('radio-buttons-styled-text', $from: $theme),
+            $iconset-version: 1,
+            $high-contrast-fallback: true
+        );
+        display: inline-block;
+        background-repeat: no-repeat;
+        background-position: 3px;
+        background-size: $_o-forms-radio-styled-icon-size $_o-forms-radio-styled-icon-size;
+        padding-left: $_o-forms-radio-styled-icon-padding;
+        &:after {
+            // Hack to download checked icon before checked, avoiding flash as icon loads.
+            content: '';
+            display: none;
+            @include oIconsGetIcon(
+                $icon-name: $icon-name,
+                $apply-base-styles: false,
+                $apply-width-height: false,
+                $color: _oFormsGet('radio-buttons-styled-checked-text', $from: $theme),
+                $iconset-version: 1,
+                $high-contrast-fallback: false
+            );
+        }
+    }
+    @at-root #{selector_unify(a, &)}.#{$class}__radio-button--current,
+    &:checked + .#{$class}__label {
+        @include oIconsGetIcon(
+            $icon-name: $icon-name,
+            $apply-base-styles: false,
+            $apply-width-height: false,
+            $color: _oFormsGet('radio-buttons-styled-checked-text', $from: $theme),
+            $iconset-version: 1,
+            $high-contrast-fallback: true
+        );
+    }
+}
+
+/// Transforms a custom theme map into brand variables. See `_brand.scss`.
+/// @access private
+/// @param {map|null} $theme - A custom theme map.
+/// @return {map} Brand variables.
+@function _oFormsThemeToBrandVariants($theme) {
+    @if $theme {
+        // Error if required theme keys are not provided.
+        $required-theme-keys: ('checked-background', 'border');
+        @each $required-theme-key in $required-theme-keys {
+            @if not index(map-keys($theme), $required-theme-key) {
+                @error "oFormsRadioButtonsStyled custom theme is missing a '#{$required-theme-key}' key.";
+            }
+        }
+        // Add default value for checked background if not specified.
+        @if not map-get($theme, 'negative-checked-background') {
+            $theme: map-merge($theme, (
+                'negative-checked-background': map-get($theme, 'checked-background')
+            ));
+        }
+        $theme: (
+            radio-buttons-styled-text: oColorsGetPaletteColor(map-get($theme, 'checked-background')),
+            radio-buttons-styled-border: oColorsGetPaletteColor(map-get($theme, 'border')),
+            radio-buttons-styled-checked-text: oColorsGetTextColor(oColorsGetPaletteColor(map-get($theme, 'checked-background')), 100),
+            radio-buttons-styled-checked-background: oColorsGetPaletteColor(map-get($theme, 'checked-background')),
+            radio-buttons-styled-negative-checked-background: oColorsGetPaletteColor(map-get($theme, 'negative-checked-background')),
+            checkbox-radio-hover-background: oColorsGetPaletteColor(map-get($theme, 'checked-background'))
+        );
+    }
+    @return $theme;
 }
 
 /// Margins for styled button labels.
 /// @access private
 @mixin _oFormsRadioButtonsStyledMargin {
-    margin: 3px 0;
+    margin: $_o-forms-radio-styled-button-gap 0;
     &:first-of-type {
-        margin: 3px 0 3px 3px;
+        margin: $_o-forms-radio-styled-button-gap 0 $_o-forms-radio-styled-button-gap $_o-forms-radio-styled-button-gap;
     }
     &:last-of-type {
-        margin: 3px 3px 3px 0;
+        margin: $_o-forms-radio-styled-button-gap $_o-forms-radio-styled-button-gap $_o-forms-radio-styled-button-gap 0;
     }
 }
 

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -294,6 +294,7 @@
             border-left: 1px solid _oFormsGet('radio-buttons-styled-border', $from: $theme);
         }
     }
+    // sass-lint:disable space-after-colon
     @at-root #{selector_unify(a, &)}:not(:disabled):not(.#{$class}__radio-button--current):hover,
     &:not(:disabled):not(:checked) + .#{$class}__label:hover {
         background-color: rgba(_oFormsGet('checkbox-radio-hover-background', $from: $theme), 0.15);
@@ -307,6 +308,7 @@
     &--negative:checked + .#{$class}__label {
         background-color: _oFormsGet('radio-buttons-styled-negative-checked-background', $from: $theme);
     }
+    // sass-lint:enable space-after-colon
 }
 
 /// @access public
@@ -340,8 +342,6 @@
         padding-left: $_o-forms-radio-styled-icon-padding;
         &:after {
             // Hack to download checked icon before checked, avoiding flash as icon loads.
-            content: '';
-            display: none;
             @include oIconsGetIcon(
                 $icon-name: $icon-name,
                 $apply-base-styles: false,
@@ -350,6 +350,8 @@
                 $iconset-version: 1,
                 $high-contrast-fallback: false
             );
+            content: '';
+            display: none;
         }
     }
     @at-root #{selector_unify(a, &)}.#{$class}__radio-button--current,

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -260,8 +260,8 @@
 }
 
 /// @access public
-/// @example
-/// .o-forms__radio-button--custom {
+/// @example scss - Creating a custom theme, 'negative-checked-background' is optional.
+/// .o-forms__radio-button--my-custom-theme {
 ///     @include oFormsRadioButtonsStyledTheme($theme: (
 ///         'checked-background': 'claret-80',
 ///         'negative-checked-background': 'claret-30',
@@ -269,7 +269,7 @@
 ///     ));
 /// }
 /// @param {string} $class - The block level class name (BEM naming convention).
-/// @param {map|null} $class - A custom theme map.
+/// @param {map|null} $theme - A custom theme map (see example).
 /// @prop {string} $class.checked-background - An Origami color name e.g. "teal-50".
 /// @prop {string} $class.border - An Origami color name for the border e.g. "black-30".
 /// @prop {string} $class.negative-checked-background [$theme.checked-background] - An Origami color for negative choice radio buttons (optional).
@@ -312,8 +312,8 @@
 }
 
 /// @access public
-/// @example
-/// .o-forms__radio-button--custom-grid-icon {
+/// @example - Adding an icon with a custom theme, 'negative-checked-background' is optional.
+/// .o-forms__radio-button--my-custom-icon {
 /// 	@include oFormsRadioButtonsStyledIcon($icon-name: 'grid', $theme: (
 /// 		'checked-background': 'claret-50',
 /// 		'border': 'black-30',


### PR DESCRIPTION
**Changes**
- Updated styled radio buttons to be smaller with less padding, intentionally closer to `o-buttons`.
- Add the ability to achieve the look of styled radio buttons but with anchor tags.
- Add the ability to customise the color of styled radio buttons and add an icon.

**Why**

To improve the MyFT page, replacing a group of `o-buttons`.

Current:
<img width="1212" alt="screen shot 2018-07-19 at 16 49 10" src="https://user-images.githubusercontent.com/10405691/42954072-b248b818-8b73-11e8-9e38-06c8d7eb2755.png">

New (wireframe, no color):
<img width="952" alt="screen shot 2018-07-19 at 16 47 51" src="https://user-images.githubusercontent.com/10405691/42953986-812ceae2-8b73-11e8-8bc9-9baffc93f02c.png">

**How**

Example of a custom theme and icon:

```scss
$_o-forms-demo-theme: (
	'checked-background': 'claret-50',
	'border': 'black-30'
);

.o-forms__radio-button--custom-theme {
	@include oFormsRadioButtonsStyledTheme($theme: $_o-forms-demo-theme);
}

.o-forms__radio-button--custom-list-icon {
	@include oFormsRadioButtonsStyledIcon($icon-name: 'list', $theme: $_o-forms-demo-theme);
}

.o-forms__radio-button--custom-grid-icon {
	@include oFormsRadioButtonsStyledIcon($icon-name: 'grid', $theme: $_o-forms-demo-theme);
}
```
```html
<div class="o-forms">
    <div class="o-forms__group o-forms__group--inline-together">
        <a href="#" class="o-forms__radio-button o-forms__radio-button--current o-forms__radio-button--custom-theme o-forms__radio-button--custom-grid-icon">
            a
        </a>
        <a href="#" class="o-forms__radio-button o-forms__radio-button--custom-theme o-forms__radio-button--custom-list-icon">
            b
        </a>
    </div>
</div>
```
<img width="150" alt="screen shot 2018-07-19 at 16 45 34" src="https://user-images.githubusercontent.com/10405691/42953843-2e95c402-8b73-11e8-9140-515117b6f900.png">

