### PR TITLE
Set font using o-typography.

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -8,10 +8,6 @@ $_o-forms-demo-theme: (
 	'negative-checked-background': 'claret-80',
 );
 
-html {
-	font-family: $o-forms-font-family;
-}
-
 body {
 	@include oColorsFor('page', 'background');
 	margin: oGridGutter();

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -13,6 +13,7 @@ $o-forms-is-silent: true !default;
 /// since `<input>`, `<textarea>`, `<select>`… don't inherit global font styles
 ///
 /// @access public
+/// @deprecated
 /// @type String
 $o-forms-font-family: $o-typography-sans !default;
 

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -207,7 +207,7 @@
 	$status-icon-padding: ($status-icon-size/40) * 10;
 	// Base status styles.
 	.#{$class}__status {
-		@include oTypographySize(-1);
+		@include oTypographySans(-1);
 		line-height: 1em;
 		white-space: nowrap;
 		align-items: center;

--- a/src/scss/mixins/_common.scss
+++ b/src/scss/mixins/_common.scss
@@ -215,7 +215,7 @@
 /// @access public
 /// @output Basic styles shared between input, textarea, select etc.
 @mixin oFormsCommonFieldBase {
-	@include oTypographySize(0);
+	@include oTypographySans(0);
 	color: _oFormsGet('field-standard-text');
 	border-color: _oFormsGet('field-standard-border');
 	background-color: _oFormsGet('field-standard-background');
@@ -228,7 +228,6 @@
 	border: $_o-forms-field-border;
 	border-radius: $_o-forms-field-border-radius;
 	background-clip: padding-box;
-	font-family: $o-forms-font-family;
 	outline: none;
 	transition: 0.15s box-shadow ease-in;
 	appearance: none;

--- a/src/scss/mixins/_labels.scss
+++ b/src/scss/mixins/_labels.scss
@@ -6,7 +6,7 @@
 /// @access public
 /// @output Styles for a label.
 @mixin oFormsLabel {
-	@include oTypographyBold('sans');
+	@include oTypographySansBold($scale: 0);
 	color: _oFormsGet('field-label-text');
 	display: block;
 	padding: 0; // Reset legend default styling
@@ -30,7 +30,7 @@
 /// @access public
 /// @output Styles for addional input information (typically below a label).
 @mixin oFormsAdditionalInfo {
-	@include oTypographySize(-1);
+	@include oTypographySans($scale: -1);
 	color: _oFormsGet('field-additional-info-text');
 	display: block;
 }
@@ -38,7 +38,7 @@
 /// @access public
 /// @output Styles for error text.
 @mixin oFormsErrorText {
-	@include oTypographySize(-1);
+	@include oTypographySans($scale: -1);
 	color: _oFormsGet('field-invalid-text');
 	clear: both;
 	display: block;

--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -207,7 +207,7 @@
     }
     @at-root #{selector_unify(a, &)},
     & + .#{$class}__label {
-		@include oTypographySize($scale: -1, $line-height: 1em);
+		@include oTypographySans($scale: -1, $line-height: 1);
         @include _oFormsRadioButtonsStyledMargin();
         cursor: pointer;
         font-weight: oFontsWeight('semibold');

--- a/src/scss/mixins/sections.scss
+++ b/src/scss/mixins/sections.scss
@@ -47,13 +47,13 @@
 /// @access public
 /// @output Styles for a message which spans multiple o-forms instances.
 @mixin oFormsMessage() {
-	@include oTypographySize(1);
+	@include oTypographySans(1);
 	background-color: _oFormsGet('section-highlight-background');
 	padding: 0 $_o-forms-padding;
 	margin-bottom: $_o-forms-spacing;
 
 	p {
-		font-family: $o-forms-font-family;
+		@include oTypographySans(1);
 		padding: oTypographySpacingSize(2) 0;
 		margin: 0;
 	}

--- a/src/scss/mixins/suffix.scss
+++ b/src/scss/mixins/suffix.scss
@@ -6,13 +6,12 @@
 /// @require {mixin} oFormsAffixWrapper - A suffix must be used within an affix wrapper.
 /// @output Styles for an input suffix.
 @mixin oFormsSuffix() {
-	@include oTypographySize(0);
+	@include oTypographySans(0);
 	display: table-cell;
 	box-sizing: border-box;
 	width: 1%;
 	white-space: nowrap;
 	padding-left: $_o-forms-field-default-padding-leftright;
-	font-family: $o-forms-font-family;
 	text-align: center;
 	vertical-align: middle;
 	user-select: none;


### PR DESCRIPTION
Uses `o-typography` to output font-family and size rather than inherit it.

These changes support custom fonts and custom font scales:
https://github.com/Financial-Times/o-typography/pull/166

This update means form elements such as labels use the line height from our typographic scale rather than the browser default line-height. The impact of this is slightly larger spacing / slightly taller form elements as shown below.

Old / New
<img width="1440" alt="screen shot 2018-11-12 at 15 48 54" src="https://user-images.githubusercontent.com/10405691/48358576-f3851900-e692-11e8-8bc5-5bec3c5546e2.png">
<img width="1440" alt="screen shot 2018-11-12 at 15 48 29" src="https://user-images.githubusercontent.com/10405691/48358585-f718a000-e692-11e8-8cee-6a32729d0ff2.png">
