### PR TITLE
Correct right aligned checkbox checked state.

### DIFF
--- a/src/scss/mixins/_radio-checkbox.scss
+++ b/src/scss/mixins/_radio-checkbox.scss
@@ -26,8 +26,7 @@
         border-radius: 9999px;
         height: $_o-forms-radio-internal-default-size;
         width: $_o-forms-radio-internal-default-size;
-        left: $_o-forms-radio-internal-offset;
-        top: $_o-forms-radio-internal-offset;
+        margin: $_o-forms-radio-internal-offset;
     }
 }
 
@@ -104,13 +103,9 @@
         text-align: right;
     }
 
+    & + .#{$class}__label::after,
     & + .#{$class}__label::before {
         right: 0;
-        left: auto;
-    }
-
-    & + .#{$class}__label::after {
-        right: $_o-forms-radio-internal-offset;
         left: auto;
     }
 }


### PR DESCRIPTION
Before
![screenshot 2018-11-22 at 14 40 21](https://user-images.githubusercontent.com/10405691/48909200-8fb5d980-ee64-11e8-88b7-23b68d484cce.png)

After
![screenshot 2018-11-22 at 14 38 06](https://user-images.githubusercontent.com/10405691/48909163-76149200-ee64-11e8-837b-a776f06f43e3.png)

This visual bug was introduced here: https://github.com/Financial-Times/o-forms/pull/230