### PR TITLE
Allow any text-like input (e.g. email) to be styled as a text input.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@ All Sass mixins have been removed, and have been replaced with two public mixins
 - `oForms()`
 - `oFormsAddCustom()`
 
-The primary mixin makes an options map public, which allows you to output styles specific to the elements that you want to use in your form. `o-forms` [no longer supports custom classes](https://github.com/Financial-Times/origami-proposals/issues/4). 
+The primary mixin makes an options map public, which allows you to output styles specific to the elements that you want to use in your form. `o-forms` [no longer supports custom classes](https://github.com/Financial-Times/origami-proposals/issues/4).
 
 The following example would output small text inputs and regular checkboxes:
 
@@ -20,7 +20,7 @@ The following example would output small text inputs and regular checkboxes:
 
 +@include oForms($opts: (
 +	'elements': (
-+		'text', 
++		'text',
 +		'checkbox'
 +	),
 +	'features': (
@@ -80,7 +80,8 @@ The root `o-forms` class is no longer used. Instead, there are modifiers for eac
 	- `.o-forms-input--radio-round`
 	- `.o-forms-input--select`
 	- `.o-forms-input--text-area`
-	- `.o-forms-input--text-input`
+	- `.o-forms-input--password`
+	- `.o-forms-input--text`
 	- `.o-forms-input--toggle`
 	- `.o-forms-input--valid`
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Regardless of the input type used, all elements follow the same structure:
 └————————————————————————————————————————┘
 ```
 
-Bearing that in mind, all form elements are divided into two main categories, with a couple of outliers: 
+Bearing that in mind, all form elements are divided into two main categories, with a couple of outliers:
 - [single input fields](#single-input-fields)
 - [multiple input fields](#multiple-input-fields)
 - [uncategorised input fields](#uncategorised-input-fields)
 
-Overall, the same modifiers will work for the structure outlined above. 
+Overall, the same modifiers will work for the structure outlined above.
 If a particular form element has a unique modifier, it will be under its markup description.
 - [Field modifiers](#field-modifiers)
 - [Input modifiers](#input-modifiers)
@@ -105,6 +105,9 @@ Every single input field requires a root structure that looks like this:
 	</span>
 ...
 ```
+
+Note: For text-like input types where `o-forms` does not provide a specific modifier class, like `type="email"`, the `o-forms-input--text` modifier may be used.
+
 [_See the full markup for text and password input in the registry_](https://registry.origami.ft.com/components/o-forms#text-input)
 #### `textarea`
 ```html
@@ -288,7 +291,7 @@ For a toggle checkbox, you'll need the following markup:
 ...
 ```
 
-This is currently the only input type that has an inverse state. 
+This is currently the only input type that has an inverse state.
 For this you'll need to add the `o-forms-field--inverse` to the parent element:
 
 ```diff
@@ -378,7 +381,7 @@ In order to provide customised error messages for an invalid input field, you'll
 	</span>
 ...
 ```
-The message is hidden by default, until the input field becomes invalid. 
+The message is hidden by default, until the input field becomes invalid.
 
 #### Error Summary
 `o-forms` also generates an error message element when a form is submitted and invalid inputs are recognised.
@@ -405,7 +408,7 @@ If you would like to be more specific about what aspects of the styles get outpu
 ));
 ```
 ### Options
-`o-forms` has many options due to its comprehensive nature.  
+`o-forms` has many options due to its comprehensive nature.
 The `$opts` map accepts two lists with the following options:
 - `'elements'`:
 	- `'checkbox'`
@@ -487,7 +490,7 @@ oForms.init()
 The default behaviour can be changed by configuring the options object:
 ```js
 oForms.init(null, {
-	useBrowserValidation: true, 
+	useBrowserValidation: true,
 	errorSummary: false
 })
 ```
@@ -506,7 +509,7 @@ new Input(myInputEl);
 
 `o-forms` has no opinion about the timing of the states—it doesn't know when to change from 'saving' to 'saved', but it has a public method that allows the project to control this (shown below).
 
-In order to set up a state, you'll need to use a method on an existing form instance. 
+In order to set up a state, you'll need to use a method on an existing form instance.
 
 This method accepts a state and a name argument. State can be one of 'saving', 'saved' or 'none', 'none' being responsible for removing the state from the input. The name argument must be the name of the inputs that will be recieving the state. For example:
 ```html
@@ -522,7 +525,7 @@ This method accepts a state and a name argument. State can be one of 'saving', '
 		</label>
 	...
 </form>
-``` 
+```
 ```js
 import oForms from 'o-forms';
 let myForm = oForms.init();

--- a/main.scss
+++ b/main.scss
@@ -70,13 +70,6 @@
 		);
 	}
 
-	@if index($elements, 'password') {
-		@include _oFormsTextInput(
-			$disabled,
-			$input-type: 'password'
-		);
-	}
-
 	@if index($elements, 'radio-round') {
 		@include _oFormsRadioRound(
 			$disabled
@@ -101,12 +94,12 @@
 		@include _oFormsTextArea($disabled);
 	}
 
-	@if index($elements, 'text') {
+	@if index($elements, 'text') or index($elements, 'password') {
 		@include _oFormsTextInput(
 			$disabled,
 			$small,
 			$suffix,
-			$input-type: 'text'
+			$include-password-selector: index($elements, 'password')
 		);
 	}
 

--- a/src/scss/_text-input.scss
+++ b/src/scss/_text-input.scss
@@ -3,17 +3,22 @@
 /// @param {Boolean} $small Whether to output small input styles
 /// @param {Boolean} $suffix Whether to output suffix styles
 /// @param {Boolean} $small Whether to output small styles
-/// @param {String} $input-type Which text-like input to style (password, email, text)
+/// @param {String} $include-password-selector Whether or not to output a password class `o-forms-input--password` as well as `o-forms-input--text`
 /// @output Styling for text inputs
 @mixin _oFormsTextInput(
 	$disabled: null,
 	$small: null,
 	$suffix: null,
-	$input-type: 'text'
+	$include-password-selector: false
 ) {
-	$element: 'input[type=#{$input-type}]';
+	$selector: '.o-forms-input--text';
+	$element: 'input';
 
-	.o-forms-input--#{$input-type} {
+	@if($include-password-selector) {
+		$selector: $selector + ', .o-forms-input--password';
+	}
+
+	#{$selector} {
 		@if $small {
 			@include _oFormsInputSmall($element);
 		}


### PR DESCRIPTION
_(review with whitespace removed)_

So input types such as `email` and `tel` may be styled as text fields,
style any `input` which is the child of `.o-forms-input--text` as a
text input.

This means we don't have to provide individual selectors for a large
and ever changing set of input types.

See issue: https://github.com/Financial-Times/o-forms/issues/272