### PR TITLE
Handle inputs with an `undefined` `valid` getter.

### DIFF
--- a/demos/src/interactive.mustache
+++ b/demos/src/interactive.mustache
@@ -1,46 +1,46 @@
 <form action="" data-o-component="o-forms">
 
-<div class="o-forms-field o-forms-field--optional" role="group" aria-labelledby="date-group-title">
-	<span class="o-forms-title" aria-hidden="true">
-		<span class="o-forms-title__main" id="date-group-title">Date input</span>
-		<span class="o-forms-title__prompt">Optional prompt text</span>
-	</span>
+	<div class="o-forms-field o-forms-field--optional" role="group" aria-labelledby="date-group-title">
+		<span class="o-forms-title" aria-hidden="true">
+			<span class="o-forms-title__main" id="date-group-title">Date input</span>
+			<span class="o-forms-title__prompt">Optional prompt text</span>
+		</span>
 
-	<span class="o-forms-input o-forms-input--date">
-		<label>
-			<input id="date" type="text" name="date" value="" pattern="[0-9]{2}" aria-label="Day (DD)" required>
-			<span class="o-forms-input__label" aria-hidden="true">DD</span>
-		</label>
-		<label>
-			<input type="text" name="date" value="" pattern="0?[1-9]|1[012]" aria-label="Month (MM)" required>
-			<span class="o-forms-input__label" aria-hidden="true">MM</span>
-		</label>
-		<label>
-			<input type="text" name="date" value="" pattern="[0-9]{4}" aria-label="Year (YYYY)" required>
-			<span class="o-forms-input__label" aria-hidden="true">YYYY</span>
-		</label>
-		<span class="o-forms-input__error">Please fill out this field with the required format (DD/MM/YYYY)</span>
-	</span>
-</div>
-
-<div class="o-forms-field" role="group" aria-labelledby="date-group-title">
-	<span class="o-forms-title" aria-hidden="true">
-		<span class="o-forms-title__main" id="date-group-title">Radio box input</span>
-	</span>
-
-	<span class="o-forms-input o-forms-input--radio-box">
-		<div class="o-forms-input--radio-box__container">
+		<span class="o-forms-input o-forms-input--date">
 			<label>
-				<input id="radio" type="radio" name="box">
-				<span class="o-forms-input__label" aria-hidden="true">Yes</span>
+				<input id="date" type="text" name="date" value="" pattern="[0-9]{2}" aria-label="Day (DD)" required>
+				<span class="o-forms-input__label" aria-hidden="true">DD</span>
 			</label>
 			<label>
-				<input type="radio" name="box" checked>
-				<span class="o-forms-input__label o-forms-input__label--negative" aria-hidden="true">No</span>
+				<input type="text" name="date" value="" pattern="0?[1-9]|1[012]" aria-label="Month (MM)" required>
+				<span class="o-forms-input__label" aria-hidden="true">MM</span>
 			</label>
-		</div>
-	</span>
-</div>
+			<label>
+				<input type="text" name="date" value="" pattern="[0-9]{4}" aria-label="Year (YYYY)" required>
+				<span class="o-forms-input__label" aria-hidden="true">YYYY</span>
+			</label>
+			<span class="o-forms-input__error">Please fill out this field with the required format (DD/MM/YYYY)</span>
+		</span>
+	</div>
+
+	<div class="o-forms-field" role="group" aria-labelledby="date-group-title">
+		<span class="o-forms-title" aria-hidden="true">
+			<span class="o-forms-title__main" id="date-group-title">Radio box input</span>
+		</span>
+
+		<span class="o-forms-input o-forms-input--radio-box">
+			<div class="o-forms-input--radio-box__container">
+				<label>
+					<input id="radio" type="radio" name="box">
+					<span class="o-forms-input__label" aria-hidden="true">Yes</span>
+				</label>
+				<label>
+					<input type="radio" name="box" checked>
+					<span class="o-forms-input__label o-forms-input__label--negative" aria-hidden="true">No</span>
+				</label>
+			</div>
+		</span>
+	</div>
 
 	<label class="o-forms-field">
 		<span class="o-forms-title">
@@ -64,5 +64,8 @@
 		</span>
 	</label>
 
-	<input class="o-buttons" type="submit"/>
+  	<input id="hidden-demo" name="hidden-demo" type="hidden" value="123">
+
+	<button class="o-buttons" type="submit">Let's get started</button>
+
 </form>

--- a/src/js/error-summary.js
+++ b/src/js/error-summary.js
@@ -49,7 +49,7 @@ class ErrorSummary {
 	static createList(inputs) {
 		let list = document.createElement('ul');
 		inputs.forEach(input => {
-			if (input.id && !input.valid) {
+			if (input.id && input.valid === false) {
 				let listItem = document.createElement('li');
 				let anchor = ErrorSummary.createAnchor(input);
 				listItem.appendChild(anchor);

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -61,6 +61,8 @@ export default `
 		</span>
 	</div>
 
+	<input id="hidden-demo" name="hidden-demo" type="hidden" value="123">
+
 	<input class="o-buttons" type="submit">
 </form>
 `;


### PR DESCRIPTION
E.g. a hidden input.

Review with whitespace hidden.

Fixes: https://github.com/Financial-Times/o-forms/issues/276