### PR TITLE
Allow the label of box radio buttons to be customised.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,57 @@ This input type also accepts a 'negative' modifier `o-forms-input__label--negati
 	</span>
 </div>
 ```
+
+Box style radio buttons may also support saving and saved states with modifier classes `loading` and `success`, with an added `o-forms-input__state-label` and `o-forms-input__state-label` element.
+
+_We recommend using the [setState method](#state) instead of adding this markup manually._
+
+```diff
+<div class="o-forms-field">
+	...
+-	<span class="o-forms-input o-forms-input--radio-box">
++	<span class="o-forms-input o-forms-input--radio-box o-forms-input--loading">
+		<div class="o-forms-input--radio-box__container">
+			<label>
+				<input type="radio" name="negative" value="Yes">
+				<span class="o-forms-input__label">Yes</span>
+			</label>
+			<label>
+				<input type="radio" name="negative" value="No"checked>
+				<span class="o-forms-input__label o-forms-input__label--negative">No</span>
+			</label>
+		</div>
++		<span class="o-forms-input__state">
++			<span class="o-forms-input__state-label">Saving</span>
++		</span>
+	</span>
+</div>
+```
+
+Previously `o-forms-input--loading` was `o-forms-input--saving` and `o-forms-input--success` was `o-forms-input--saved`. These are now deprecated. They included the state label via CSS which can not be customised or localised reliably.
+
+_This example is deprecated. Use the above markup or the [setState method](#state) instead._
+
+```diff
+<div class="o-forms-field">
+	...
+-	<span class="o-forms-input o-forms-input--radio-box">
++	<span class="o-forms-input o-forms-input--radio-box o-forms-input--saving">
+		<div class="o-forms-input--radio-box__container">
+			<label>
+				<input type="radio" name="negative" value="Yes">
+				<span class="o-forms-input__label">Yes</span>
+			</label>
+			<label>
+				<input type="radio" name="negative" value="No"checked>
+				<span class="o-forms-input__label o-forms-input__label--negative">No</span>
+			</label>
+		</div>
++		<span class="o-forms-input__state"></span>
+	</span>
+</div>
+```
+
 [_See the full markup for a box-style radio button in the registry_](https://registry.origami.ft.com/components/o-forms#radio-box)
 
 #### `input[type=checkbox]`
@@ -507,11 +558,10 @@ new Input(myInputEl);
 ### State
 `o-forms` offers the ability to display a 'saving' or 'saved' state. However, currently the only input that accepts state is the [box-styled `input[type=radio]`](#inputtyperadio-box). If you would like to apply state to any other input, please [get in touch with the team](#contact).
 
-`o-forms` has no opinion about the timing of the states—it doesn't know when to change from 'saving' to 'saved', but it has a public method that allows the project to control this (shown below).
+`o-forms` has no opinion about the timing of the states—it doesn't know when to change from 'saving' to 'saved', but it has a public method `setState` that allows the project to control this.
 
-In order to set up a state, you'll need to use a method on an existing form instance.
+The `setState` method accepts three arguments: the state, name, and label. State can be one of 'saving', 'saved' or 'none'. 'none' removes any state from the input. The name argument must be the name of the inputs that will be recieving the state. Label is used in the user interface to describe the state. Label is optional and defaults to 'Saving' for the saving state and 'Saved' for the saving state.
 
-This method accepts a state and a name argument. State can be one of 'saving', 'saved' or 'none', 'none' being responsible for removing the state from the input. The name argument must be the name of the inputs that will be recieving the state. For example:
 ```html
 <form data-o-component="o-forms">
 	...
@@ -526,6 +576,7 @@ This method accepts a state and a name argument. State can be one of 'saving', '
 	...
 </form>
 ```
+
 ```js
 import oForms from 'o-forms';
 let myForm = oForms.init();
@@ -533,12 +584,22 @@ let myForm = oForms.init();
 myForm.setState('saving', 'my-radio-box');
 ```
 
-You also have the option of displaying state as an icon without text. In order to do this, you can call the method above with an extra argument:
+To change the saving label pass a third argument, e.g. to update the label from "Saving" to "Sending":
 
-```js
-myForm.setState('saving', 'my-radio-box', iconOnly: true);
+```diff
+-myForm.setState('saving', 'my-radio-box');
++myForm.setState('saving', 'my-radio-box', {
++	iconLabel: 'Sending'
++});
 ```
 
+You also have the option of displaying state as an icon without text. In order to do this, you can call the method above with an extra options argument:
+
+```js
+myForm.setState('saving', 'my-radio-box', {
+	iconOnly: true
+});
+```
 
 ## Migration
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ This input type also accepts a 'negative' modifier `o-forms-input__label--negati
 </div>
 ```
 
-Box style radio buttons may also support saving and saved states with modifier classes `loading` and `success`, with an added `o-forms-input__state-label` and `o-forms-input__state-label` element.
+Box style radio buttons may also support saving and saved states. Add a modifier classes `o-forms-input--loading` or `o-forms-input--success`, and the `o-forms-input__state-label` element with your copy.
 
 _We recommend using the [setState method](#state) instead of adding this markup manually._
 
@@ -499,7 +499,7 @@ It accepts four arguments:
 	- `'controls-negative-checked-background'`: the background color for a 'negative' checked input
 
 ```scss
-@include oFormsAddCustom({
+@include oFormsAddCustom((
 	$input: 'radio',
 	$modifier: 'my-theme', // outputs the class 'o-forms-input--my-theme',
 	$icons: 'burger'
@@ -508,7 +508,7 @@ It accepts four arguments:
 		controls-checked-base: 'white',
 		controls-negative-checked-background: 'claret-30'
 	)
-})
+));
 ```
 
 ## Accessibility

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ To show no state label add the `o-forms-input__state--icon-only` modifier class.
 </div>
 ```
 
-If you would like custom copy for the "saving" or "saved" state put in within the `o-forms-input__state` element, and add the modifier class `o-forms-input__state--custom`. _We recommend setting a custom label using the [setState method](#state) JS method instead of adding this markup manually._
+If you would like custom copy for the "saving" or "saved" state put it within the `o-forms-input__state` element, and add the modifier class `o-forms-input__state--custom`. _We recommend setting a custom label using the [setState method](#state) JS method instead of adding this markup manually._
 
 ```diff
 <div class="o-forms-field">

--- a/README.md
+++ b/README.md
@@ -237,35 +237,9 @@ This input type also accepts a 'negative' modifier `o-forms-input__label--negati
 </div>
 ```
 
-Box style radio buttons may also support saving and saved states. Add a modifier classes `o-forms-input--loading` or `o-forms-input--success`, and the `o-forms-input__state-label` element with your copy.
+Box style radio buttons may also support saving and saved states. Add a modifier classes `o-forms-input--saving` or `o-forms-input--saved`, and the `o-forms-input__state` element.
 
 _We recommend using the [setState method](#state) instead of adding this markup manually._
-
-```diff
-<div class="o-forms-field">
-	...
--	<span class="o-forms-input o-forms-input--radio-box">
-+	<span class="o-forms-input o-forms-input--radio-box o-forms-input--loading">
-		<div class="o-forms-input--radio-box__container">
-			<label>
-				<input type="radio" name="negative" value="Yes">
-				<span class="o-forms-input__label">Yes</span>
-			</label>
-			<label>
-				<input type="radio" name="negative" value="No"checked>
-				<span class="o-forms-input__label o-forms-input__label--negative">No</span>
-			</label>
-		</div>
-+		<span class="o-forms-input__state">
-+			<span class="o-forms-input__state-label">Saving</span>
-+		</span>
-	</span>
-</div>
-```
-
-Previously `o-forms-input--loading` was `o-forms-input--saving` and `o-forms-input--success` was `o-forms-input--saved`. These are now deprecated. They included the state label via CSS which can not be customised or localised reliably.
-
-_This example is deprecated. Use the above markup or the [setState method](#state) instead._
 
 ```diff
 <div class="o-forms-field">
@@ -283,6 +257,53 @@ _This example is deprecated. Use the above markup or the [setState method](#stat
 			</label>
 		</div>
 +		<span class="o-forms-input__state"></span>
+	</span>
+</div>
+```
+
+To show no state label add the `o-forms-input__state--icon-only` modifier class.
+```diff
+<div class="o-forms-field">
+	...
+-	<span class="o-forms-input o-forms-input--radio-box">
++	<span class="o-forms-input o-forms-input--radio-box o-forms-input--saving">
+		<div class="o-forms-input--radio-box__container">
+			<label>
+				<input type="radio" name="negative" value="Yes">
+				<span class="o-forms-input__label">Yes</span>
+			</label>
+			<label>
+				<input type="radio" name="negative" value="No"checked>
+				<span class="o-forms-input__label o-forms-input__label--negative">No</span>
+			</label>
+		</div>
+-		<span class="o-forms-input__state"></span>
++		<span class="o-forms-input__state o-forms-input__state--icon-only"></span>
+	</span>
+</div>
+```
+
+If you would like custom copy for the "saving" or "saved" state put in within the `o-forms-input__state` element, and add the modifier class `o-forms-input__state--custom`. _We recommend setting a custom label using the [setState method](#state) JS method instead of adding this markup manually._
+
+```diff
+<div class="o-forms-field">
+	...
+-	<span class="o-forms-input o-forms-input--radio-box">
++	<span class="o-forms-input o-forms-input--radio-box o-forms-input--saving">
+		<div class="o-forms-input--radio-box__container">
+			<label>
+				<input type="radio" name="negative" value="Yes">
+				<span class="o-forms-input__label">Yes</span>
+			</label>
+			<label>
+				<input type="radio" name="negative" value="No"checked>
+				<span class="o-forms-input__label o-forms-input__label--negative">No</span>
+			</label>
+		</div>
+-		<span class="o-forms-input__state"></span>
++		<span class="o-forms-input__state o-forms-input__state--custom">
++			Processing
++		</span>
 	</span>
 </div>
 ```

--- a/demos/src/data/radio-box.json
+++ b/demos/src/data/radio-box.json
@@ -177,7 +177,7 @@
 					"label": "saving-state-group-title",
 					"info": "saving-state-group-info"
 				},
-				"modifiers": ["loading"],
+				"modifiers": ["saving"],
 				"state": "Saving"
 			},
 			"title": {
@@ -206,7 +206,7 @@
 				"aria": {
 					"label": "saved-state-group-title"
 				},
-				"modifiers": ["success", "inline"],
+				"modifiers": ["saved", "inline"],
 				"state": "Saved"
 			},
 			"title": {
@@ -235,7 +235,7 @@
 					"label": "saving-state-group-title",
 					"info": "saving-state-group-info"
 				},
-				"modifiers": [ "loading", "inline" ],
+				"modifiers": [ "saving", "inline" ],
 				"state": "Saving",
 				"icon": true
 			},

--- a/demos/src/data/radio-box.json
+++ b/demos/src/data/radio-box.json
@@ -148,8 +148,7 @@
 				"aria": {
 					"label": "inline-radio-box-group-title"
 				},
-				"modifiers": ["inline"],
-				"state": true
+				"modifiers": ["inline"]
 			},
 			"title": {
 				"main": "V-centered inline radio box",
@@ -178,8 +177,8 @@
 					"label": "saving-state-group-title",
 					"info": "saving-state-group-info"
 				},
-				"modifiers": ["saving"],
-				"state": true
+				"modifiers": ["loading"],
+				"state": "Saving"
 			},
 			"title": {
 				"main": "Inline box-style radio buttons",
@@ -207,8 +206,8 @@
 				"aria": {
 					"label": "saved-state-group-title"
 				},
-				"modifiers": ["saved", "inline"],
-				"state": true
+				"modifiers": ["success", "inline"],
+				"state": "Saved"
 			},
 			"title": {
 				"main": "Inline saved state"
@@ -236,8 +235,8 @@
 					"label": "saving-state-group-title",
 					"info": "saving-state-group-info"
 				},
-				"modifiers": [ "saving", "inline" ],
-				"state": true,
+				"modifiers": [ "loading", "inline" ],
+				"state": "Saving",
 				"icon": true
 			},
 			"title": {

--- a/demos/src/interactive.js
+++ b/demos/src/interactive.js
@@ -10,6 +10,6 @@ for (let input of inputs) {
 		let name = e.target.name;
 		form.setState('saving', name, { iconLabel: 'pretend saving'});
 		setTimeout(() => form.setState('saved', name, { iconLabel: 'pretend saved'}), 400);
-		setTimeout(() => form.setState('none', name), 1000);
+
 	});
 }

--- a/demos/src/interactive.js
+++ b/demos/src/interactive.js
@@ -8,8 +8,8 @@ let inputs = formEl.querySelectorAll('input[type="radio"]');
 for (let input of inputs) {
 	input.addEventListener('click', (e) => {
 		let name = e.target.name;
-		form.setState('saving', name);
-		setTimeout(() => form.setState('saved', name), 400);
+		form.setState('saving', name, { iconLabel: 'pretend saving'});
+		setTimeout(() => form.setState('saved', name, { iconLabel: 'pretend saved'}), 400);
 		setTimeout(() => form.setState('none', name), 1000);
 	});
 }

--- a/demos/src/multiple-input-field.mustache
+++ b/demos/src/multiple-input-field.mustache
@@ -14,18 +14,18 @@
 {{^anchor}}
 
 {{#inverse}}<div class="demo-inverse">{{/inverse}}
-	
+
 	<div class="o-forms-field
 		{{#inline-field}} o-forms-field--inline{{/inline-field}}
 		{{#inverse}} o-forms-field--inverse{{/inverse}}
 		{{#optional}} o-forms-field--optional{{/optional}}
-		{{#custom}} demo-custom-radio-theme{{/custom}}" 
-		role="group" 
+		{{#custom}} demo-custom-radio-theme{{/custom}}"
+		role="group"
 		{{#field.aria}}
 			aria-labelledby="{{label}}"
 			{{#info}}aria-describedby="{{info}}"{{/info}}
 		{{/field.aria}}>
-		
+
 		<span	class="o-forms-title" aria-hidden="true">
 			<span class="o-forms-title__main" id="{{field.aria.label}}">{{title.main}}</span>
 			{{#title.prompt}}
@@ -39,13 +39,13 @@
 
 			{{#inputs}}
 				<label {{#label}}class="{{.}}"{{/label}}>
-					<input 
-						type="{{type}}" 
+					<input
+						type="{{type}}"
 						name="{{name}}"
-						value="{{value}}" 
-						{{#pattern}}pattern={{.}}{{/pattern}} 
-						aria-label="{{value}}" 
-						{{#checked}}checked{{/checked}} 
+						value="{{value}}"
+						{{#pattern}}pattern={{.}}{{/pattern}}
+						aria-label="{{value}}"
+						{{#checked}}checked{{/checked}}
 						{{#disabled}}disabled{{/disabled}}
 						{{^disabled}}{{^optional}}required{{/optional}}{{/disabled}}>
 
@@ -67,9 +67,11 @@
 
 			{{#field.error}}<span class="o-forms-input__error">{{.}}</span>{{/field.error}}
 
-			{{#field.state}}<span class="o-forms-input__state {{#field.icon}}o-forms-input__state--icon-only{{/field.icon}}"></span>{{/field.state}}
+			{{#field.state}}
+				<span class="o-forms-input__state {{#field.icon}}o-forms-input__state--icon-only{{/field.icon}}">{{#field.state}}<span class="o-forms-input__state-label">{{field.state}}</span>{{/field.state}}</span>
+			{{/field.state}}
 		</span>
-	
+
 	</div>
 
 {{#inverse}}</div>{{/inverse}}

--- a/demos/src/multiple-input-field.mustache
+++ b/demos/src/multiple-input-field.mustache
@@ -68,7 +68,8 @@
 			{{#field.error}}<span class="o-forms-input__error">{{.}}</span>{{/field.error}}
 
 			{{#field.state}}
-				<span class="o-forms-input__state {{#field.icon}}o-forms-input__state--icon-only{{/field.icon}}">{{#field.state}}<span class="o-forms-input__state-label">{{field.state}}</span>{{/field.state}}</span>
+				<span class="o-forms-input__state {{#field.icon}}o-forms-input__state--icon-only{{/field.icon}}">
+				</span>
 			{{/field.state}}
 		</span>
 

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -124,18 +124,36 @@ class Forms {
 	* Input state
 	* @param {String} [name] - name of the input fields to add state to
 	* @param {String} [state] - type of state to apply — one of 'saving', 'saved', 'none'
+	* @param {boolean|object} [options] - an object of options display an icon only when true, hiding the status label
 	*/
-	setState(state, name, iconOnly = false) {
+
+	/**
+	 *
+	 * @param {String} state - name of the input fields to add state to
+	 * @param {String} name - type of state to apply — one of 'saving', 'saved', 'none'
+	 * @param {Boolean|Object} options - an object of options (deprecated: boolean, to set the `iconOnly` option).
+	 * @param {String} options.iconLabel [null] - customise the label of the state, e.g. the saved state defaults to "Saving" but could be "Sent"
+	 * @param {Boolean} options.iconOnly [false] - when true display an icon only, hiding the status label
+	 */
+	setState(state, name, options = { iconLabel: null, iconOnly: false }) {
+		// Handle deprecated interface.
+		// setState(state, name, iconOnly)
+		if (typeof options === 'boolean') {
+			options = {
+				iconOnly: options
+			};
+		}
+
 		let object = this.stateElements.find(item => item.name === name);
 		if (!object) {
 			object = {
 				name,
-				element: new State(this.form.elements[name], { iconOnly })
+				element: new State(this.form.elements[name], options)
 			};
 
 			this.stateElements.push(object);
 		}
-		object.element.set(state);
+		object.element.set(state, options.iconLabel);
 	}
 
 	/**

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -136,7 +136,7 @@ class Forms {
 	 * @param {Boolean} options.iconOnly [false] - when true display an icon only, hiding the status label
 	 */
 	setState(state, name, options = { iconLabel: null, iconOnly: false }) {
-		// Handle deprecated interface.
+		// @deprecated: this condition handles the deprecated use of a boolean third argument
 		// setState(state, name, iconOnly)
 		if (typeof options === 'boolean') {
 			console.warn('The `setState` method accepting a boolean third argument has been deprecated and will be removed in a later version. Please use an options object with a boolean `iconOnly` property instead.');

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -139,6 +139,7 @@ class Forms {
 		// Handle deprecated interface.
 		// setState(state, name, iconOnly)
 		if (typeof options === 'boolean') {
+			console.warn('The `setState` method accepting a boolean third argument has been deprecated and will be removed in a later version. Please use an options object with a boolean `iconOnly` property instead.');
 			options = {
 				iconOnly: options
 			};

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -2,6 +2,8 @@ class State {
 	/**
 	* Class constructor.
 	* @param {RadioNodeList} [inputs] - A NodeList of radio input elements
+	 * @param {Boolean|Object} opts - an object of options
+	 * @param {String} options.iconOnly [null] - when true display an icon only, hiding the status label
 	*/
 	constructor(inputs, opts) {
 		let radioInputs = inputs instanceof RadioNodeList;
@@ -18,8 +20,8 @@ class State {
 		}, opts);
 
 		this.className = {
-			saving: 'o-forms-input--saving',
-			saved: 'o-forms-input--saved'
+			saving: 'o-forms-input--loading',
+			saved: 'o-forms-input--success'
 		};
 	}
 
@@ -29,6 +31,8 @@ class State {
 	*/
 	_generateStateEl() {
 		this.stateEl = document.createElement('span');
+		this.stateElLabel = document.createElement('span');
+		this.stateEl.appendChild(this.stateElLabel);
 		let classNames = this.opts.iconOnly ? ['o-forms-input__state', 'o-forms-input__state--icon-only'] : ['o-forms-input__state'];
 		 this.stateEl.classList.add(...classNames);
 		this.parent.append(this.stateEl);
@@ -36,17 +40,18 @@ class State {
 
 	/**
 	* State setter
-	* @param {String} [state] type of state to display
+	* @param {String} state type of state to display
+	* @param {String} label customise the label of the state, e.g. the saved state defaults to "Saving" but could be "Sent"
 	*/
-	set(state) {
+	set(state, label) {
 		if (!this.stateEl) {
 			this._generateStateEl();
 		}
 
 		if (state === 'saving') {
-			this._saving();
+			this._saving(label);
 		} else if (state === 'saved') {
-			this._saved();
+			this._saved(label);
 		} else if (state === 'none') {
 			this._remove();
 		} else {
@@ -58,7 +63,9 @@ class State {
 	* Saving state
 	* @access private
 	*/
-	_saving() {
+	_saving(label) {
+		this.stateElLabel.textContent = label || 'Saving';
+		this.parent.classList.remove(this.className.saved);
 		this.parent.classList.add(this.className.saving);
 	}
 
@@ -66,8 +73,10 @@ class State {
 	* Saved state
 	* @access private
 	*/
-	_saved() {
-		this.parent.classList.replace(this.className.saving, this.className.saved);
+	_saved(label) {
+		this.stateElLabel.textContent = label || 'Saved';
+		this.parent.classList.remove(this.className.saving);
+		this.parent.classList.add(this.className.saved);
 	}
 
 	/**
@@ -75,6 +84,7 @@ class State {
 	* @access private
 	*/
 	_remove() {
+		this.parent.classList.remove(this.className.saving);
 		this.parent.classList.remove(this.className.saved);
 		this.parent.removeChild(this.stateEl);
 		this.stateEl = null;

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -20,8 +20,8 @@ class State {
 		}, opts);
 
 		this.className = {
-			saving: 'o-forms-input--loading',
-			saved: 'o-forms-input--success'
+			saving: 'o-forms-input--saving',
+			saved: 'o-forms-input--saved'
 		};
 	}
 
@@ -31,8 +31,6 @@ class State {
 	*/
 	_generateStateEl() {
 		this.stateEl = document.createElement('span');
-		this.stateElLabel = document.createElement('span');
-		this.stateEl.appendChild(this.stateElLabel);
 		let classNames = this.opts.iconOnly ? ['o-forms-input__state', 'o-forms-input__state--icon-only'] : ['o-forms-input__state'];
 		 this.stateEl.classList.add(...classNames);
 		this.parent.append(this.stateEl);
@@ -64,9 +62,17 @@ class State {
 	* @access private
 	*/
 	_saving(label) {
-		this.stateElLabel.textContent = label || 'Saving';
+		// Remove other state classes.
 		this.parent.classList.remove(this.className.saved);
+		// Add saving state class.
 		this.parent.classList.add(this.className.saving);
+		// Add custom state label if given.
+		// Default label copy is added via the CSS `content` attribute.
+		this.stateEl.classList.toggle('o-forms-input__state--custom', Boolean(label));
+		this.stateEl.textContent = label && !this.opts.iconOnly ? label : '';
+		// When icon-only is set there is no copy when given a custom label so
+		// add an aria label.
+		this.stateEl.setAttribute('aria-label', label || 'Saving');
 	}
 
 	/**
@@ -74,9 +80,17 @@ class State {
 	* @access private
 	*/
 	_saved(label) {
-		this.stateElLabel.textContent = label || 'Saved';
+		// Remove other state classes.
 		this.parent.classList.remove(this.className.saving);
+		// Add saved state class.
 		this.parent.classList.add(this.className.saved);
+		// Add custom state label if given.
+		// Default label copy is added via the CSS `content` attribute.
+		this.stateEl.classList.toggle('o-forms-input__state--custom', Boolean(label));
+		this.stateEl.textContent = label && !this.opts.iconOnly ? label : '';
+		// When icon-only is set there is no copy when given a custom label so
+		// add an aria label.
+		this.stateEl.setAttribute('aria-label', label || 'Saved');
 	}
 
 	/**

--- a/src/scss/modifiers/_state.scss
+++ b/src/scss/modifiers/_state.scss
@@ -2,12 +2,13 @@
 /// @output styles for state animation for the box-styled radio inputs
 @mixin _oFormsState() {
 	.o-forms-input__state {
-		// the loading spinner and tick icons for state are mismatched in terms of size/padding, 
+		// the loading spinner and tick icons for state are mismatched in terms of size/padding,
 		// the custom line-height aligns them as closely as possible (with minimal style changes)
 		@include oTypographySize($scale: -1, $line-height: 1.75);
 		color: inherit;
 		display: block;
 
+		> .o-forms-input__state-label,
 		&:before,
 		&:after {
 			content: '';
@@ -15,20 +16,19 @@
 		}
 	}
 
+	.o-forms-input__state--icon-only .o-forms-input__state-label,
 	.o-forms-input__state--icon-only:after {
 		@include oNormaliseVisuallyHidden;
 	}
 
+	// Generic loading (for custom copy) and saving status styles.
+	.o-forms-input--loading,
 	.o-forms-input--saving {
 		display: block;
 
 		.o-forms-input__state {
 			padding: 0;
 
-			&:after {
-				content: 'Saving';
-			}
-			
 			&:before {
 				@include oLoadingContent($opts: ('theme': 'dark', 'size': 'mini'));
 				margin: 0 $_o-forms-spacing-two 0 0;
@@ -36,14 +36,16 @@
 		}
 	}
 
+	// Generic success (for custom copy) and saved status styles.
+	.o-forms-input--success,
 	.o-forms-input--saved {
 		display: block;
 
 		.o-forms-input__state {
 			margin-left: -$_o-forms-spacing-one;
 
-			&:after {
-				content: 'Saved';
+			&:after,
+			> .o-forms-input__state-label {
 				color: _oFormsGet('valid-base');
 			}
 
@@ -55,8 +57,33 @@
 		}
 	}
 
+	// Hide label copy for saving and saved status.
+	// Copy is provided with a pseudo element.
+	.o-forms-input--saved,
+	.o-forms-input--saving {
+		.o-forms-input__state > .o-forms-input__state-label {
+			display: none;
+		}
+	}
+
+	// Saving status copy.
+	.o-forms-input--saving {
+		.o-forms-input__state:after {
+			content: 'Saving';
+		}
+	}
+
+	// Saved status copy.
+	.o-forms-input--saved {
+		.o-forms-input__state:after {
+			content: 'Saved';
+		}
+	}
+
 	@include oGridRespondTo(S) {
 		.o-forms-input--inline {
+			&.o-forms-input--loading,
+			&.o-forms-input--success,
 			&.o-forms-input--saving,
 			&.o-forms-input--saved {
 				flex-direction: row-reverse;
@@ -71,10 +98,12 @@
 				}
 			}
 
+			&.o-forms-input--loading .o-forms-input__state,
 			&.o-forms-input--saving .o-forms-input__state {
 				padding: 0 $_o-forms-spacing-three;
 			}
 
+			&.o-forms-input--success .o-forms-input__state,
 			&.o-forms-input--saved .o-forms-input__state {
 				padding: 0 $_o-forms-spacing-three 0 $_o-forms-spacing-two;
 			}

--- a/src/scss/modifiers/_state.scss
+++ b/src/scss/modifiers/_state.scss
@@ -6,28 +6,38 @@
 		// the custom line-height aligns them as closely as possible (with minimal style changes)
 		@include oTypographySize($scale: -1, $line-height: 1.75);
 		color: inherit;
-		display: block;
+		display: flex;
+		align-items: center;
 
-		> .o-forms-input__state-label,
 		&:before,
 		&:after {
 			content: '';
-			vertical-align: middle;
 		}
 	}
 
-	.o-forms-input__state--icon-only .o-forms-input__state-label,
 	.o-forms-input__state--icon-only:after {
 		@include oNormaliseVisuallyHidden;
 	}
 
-	// Generic loading (for custom copy) and saving status styles.
-	.o-forms-input--loading,
+	// Hide pseudo element text for saving and saved status.
+	// So the user can provide custom copy.
+	// E.g. they may chooise "Sent" instead of "Saved",
+	// or need to localise the copy.
+	.o-forms-input__state--custom:after {
+		display: none;
+	}
+
+	// Saving status styles.
 	.o-forms-input--saving {
 		display: block;
 
+
 		.o-forms-input__state {
 			padding: 0;
+
+			&:after {
+				content: 'Saving';
+			}
 
 			&:before {
 				@include oLoadingContent($opts: ('theme': 'dark', 'size': 'mini'));
@@ -36,54 +46,26 @@
 		}
 	}
 
-	// Generic success (for custom copy) and saved status styles.
-	.o-forms-input--success,
+	// Saved status styles.
 	.o-forms-input--saved {
 		display: block;
+		color: _oFormsGet('valid-base');
 
 		.o-forms-input__state {
 			margin-left: -$_o-forms-spacing-one;
 
-			&:after,
-			> .o-forms-input__state-label {
-				color: _oFormsGet('valid-base');
+			&:after {
+				content: 'Saved';
 			}
 
 			&:before {
 				@include oIconsGetIcon('tick', _oFormsGet('valid-base'), $_o-forms-spacing-seven);
-				vertical-align: middle;
-				padding: 0;
 			}
-		}
-	}
-
-	// Hide label copy for saving and saved status.
-	// Copy is provided with a pseudo element.
-	.o-forms-input--saved,
-	.o-forms-input--saving {
-		.o-forms-input__state > .o-forms-input__state-label {
-			display: none;
-		}
-	}
-
-	// Saving status copy.
-	.o-forms-input--saving {
-		.o-forms-input__state:after {
-			content: 'Saving';
-		}
-	}
-
-	// Saved status copy.
-	.o-forms-input--saved {
-		.o-forms-input__state:after {
-			content: 'Saved';
 		}
 	}
 
 	@include oGridRespondTo(S) {
 		.o-forms-input--inline {
-			&.o-forms-input--loading,
-			&.o-forms-input--success,
 			&.o-forms-input--saving,
 			&.o-forms-input--saved {
 				flex-direction: row-reverse;
@@ -98,12 +80,10 @@
 				}
 			}
 
-			&.o-forms-input--loading .o-forms-input__state,
 			&.o-forms-input--saving .o-forms-input__state {
 				padding: 0 $_o-forms-spacing-three;
 			}
 
-			&.o-forms-input--success .o-forms-input__state,
 			&.o-forms-input--saved .o-forms-input__state {
 				padding: 0 $_o-forms-spacing-three 0 $_o-forms-spacing-two;
 			}

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -119,19 +119,19 @@ describe('Forms', () => {
 
 		it('`saving` to named input', () => {
 			form.setState('saving', name);
-			proclaim.isTrue(parentClass(radioInputs[0], 'loading'));
+			proclaim.isTrue(parentClass(radioInputs[0], 'saving'));
 		});
 
 		it('`saved` to named input', () => {
 			form.setState('saved', name);
-			proclaim.isFalse(parentClass(radioInputs[0], 'loading'));
-			proclaim.isTrue(parentClass(radioInputs[0], 'success'));
+			proclaim.isFalse(parentClass(radioInputs[0], 'saving'));
+			proclaim.isTrue(parentClass(radioInputs[0], 'saved'));
 		});
 
 		it('`none` to named input', () => {
 			form.setState('none', name);
-			proclaim.isFalse(parentClass(radioInputs[0], 'loading'));
-			proclaim.isFalse(parentClass(radioInputs[0], 'success'));
+			proclaim.isFalse(parentClass(radioInputs[0], 'saving'));
+			proclaim.isFalse(parentClass(radioInputs[0], 'saved'));
 		});
 	});
 

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -119,19 +119,19 @@ describe('Forms', () => {
 
 		it('`saving` to named input', () => {
 			form.setState('saving', name);
-			proclaim.isTrue(parentClass(radioInputs[0], 'saving'));
+			proclaim.isTrue(parentClass(radioInputs[0], 'loading'));
 		});
 
 		it('`saved` to named input', () => {
 			form.setState('saved', name);
-			proclaim.isFalse(parentClass(radioInputs[0], 'saving'));
-			proclaim.isTrue(parentClass(radioInputs[0], 'saved'));
+			proclaim.isFalse(parentClass(radioInputs[0], 'loading'));
+			proclaim.isTrue(parentClass(radioInputs[0], 'success'));
 		});
 
 		it('`none` to named input', () => {
 			form.setState('none', name);
-			proclaim.isFalse(parentClass(radioInputs[0], 'saving'));
-			proclaim.isFalse(parentClass(radioInputs[0], 'saved'));
+			proclaim.isFalse(parentClass(radioInputs[0], 'loading'));
+			proclaim.isFalse(parentClass(radioInputs[0], 'success'));
 		});
 	});
 

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -36,34 +36,50 @@ describe('State', () => {
 
 	context('.set()', () => {
 		let stateClass;
+		let getStateText;
 
-		before(() => {
+		beforeEach(() => {
 			document.body.innerHTML = formFixture;
 			form = document.forms[0];
 			nodeList = form.elements['radioBox'];
 			state = new State(nodeList);
 			stateClass = (state) => nodeList[0].closest('.o-forms-input').classList.contains(`o-forms-input--${state}`);
+			getStateText = () => nodeList[0].closest('.o-forms-input').querySelector('.o-forms-input__state').textContent;
 		});
 
-		after(() => {
+		afterEach(() => {
 			document.body.innerHTML = null;
 		});
 
 		it('`saving` state', () => {
 			state.set('saving');
-			proclaim.isTrue(stateClass('saving'));
+			proclaim.isTrue(stateClass('loading'));
+			proclaim.equal(getStateText(), 'Saving');
+		});
+
+		it('`saving` state with custom label', () => {
+			state.set('saving', 'sending');
+			proclaim.isTrue(stateClass('loading'));
+			proclaim.equal(getStateText(), 'sending');
 		});
 
 		it('`saved` state', () => {
 			state.set('saved');
-			proclaim.isFalse(stateClass('saving'));
-			proclaim.isTrue(stateClass('saved'));
+			proclaim.isFalse(stateClass('loading'));
+			proclaim.isTrue(stateClass('success'));
+			proclaim.equal(getStateText(), 'Saved');
+		});
+
+		it('`saved` state with custom label', () => {
+			state.set('saving', 'sent');
+			proclaim.isTrue(stateClass('loading'));
+			proclaim.equal(getStateText(), 'sent');
 		});
 
 		it('`none` state', () => {
 			state.set('none');
-			proclaim.isFalse(stateClass('saving'));
-			proclaim.isFalse(stateClass('saved'));
+			proclaim.isFalse(stateClass('loading'));
+			proclaim.isFalse(stateClass('success'));
 		});
 	});
 

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -71,8 +71,8 @@ describe('State', () => {
 		});
 
 		it('`saved` state with custom label', () => {
-			state.set('saving', 'sent');
-			proclaim.isTrue(stateClass('loading'));
+			state.set('saved', 'sent');
+			proclaim.isTrue(stateClass('success'));
 			proclaim.equal(getStateText(), 'sent');
 		});
 

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -53,33 +53,31 @@ describe('State', () => {
 
 		it('`saving` state', () => {
 			state.set('saving');
-			proclaim.isTrue(stateClass('loading'));
-			proclaim.equal(getStateText(), 'Saving');
+			proclaim.isTrue(stateClass('saving'));
 		});
 
 		it('`saving` state with custom label', () => {
 			state.set('saving', 'sending');
-			proclaim.isTrue(stateClass('loading'));
+			proclaim.isTrue(stateClass('saving'));
 			proclaim.equal(getStateText(), 'sending');
 		});
 
 		it('`saved` state', () => {
 			state.set('saved');
-			proclaim.isFalse(stateClass('loading'));
-			proclaim.isTrue(stateClass('success'));
-			proclaim.equal(getStateText(), 'Saved');
+			proclaim.isFalse(stateClass('saving'));
+			proclaim.isTrue(stateClass('saved'));
 		});
 
 		it('`saved` state with custom label', () => {
 			state.set('saved', 'sent');
-			proclaim.isTrue(stateClass('success'));
+			proclaim.isTrue(stateClass('saved'));
 			proclaim.equal(getStateText(), 'sent');
 		});
 
 		it('`none` state', () => {
 			state.set('none');
-			proclaim.isFalse(stateClass('loading'));
-			proclaim.isFalse(stateClass('success'));
+			proclaim.isFalse(stateClass('saving'));
+			proclaim.isFalse(stateClass('saved'));
 		});
 	});
 


### PR DESCRIPTION
Relates to the saving/saved states in this demo: https://www.ft.com/__origami/service/build/v2/demos/o-forms@7.0.11/radio-box?brand=master
<img width="516" alt="Screenshot 2019-09-23 at 17 44 40 1" src="https://user-images.githubusercontent.com/10405691/65445320-d9c36f00-de29-11e9-8841-ae9635c68c55.png">

The classes `o-forms-input--saving` and `o-forms-input--saved`
add an icon and "Saving" or "Saved" copy to an element
`<span class="o-forms-input__state"></span>`.

These modifier classes and state element may be set using the
`setState` JS method, but may also be added manually.

As the `o-forms-input--saving` and `o-forms-input--saved` classes
add copy using pseudo elements the label of the state is not
customisable. E.g. "Saved" can't be changed to "Sent" where it
makes sense for the ui, and also the copy can't be localised.

Instead of including the copy for `saving` and `saved` states via
CSS, this PR proposes adding the copy via HTML. This may be
customised and localised. To do that whilst remaining backward
compatibile a new class `o-forms-input__state--custom` has been
added. It hides the pseudo element for the text label, so a custom
one may be added instead e.g.


```diff
<div class="o-forms-field">
	...
	<span class="o-forms-input o-forms-input--radio-box o-forms-input--saving">
		<div class="o-forms-input--radio-box__container">
			<label>
				<input type="radio" name="negative" value="Yes">
				<span class="o-forms-input__label">Yes</span>
			</label>
			<label>
				<input type="radio" name="negative" value="No"checked>
				<span class="o-forms-input__label o-forms-input__label--negative">No</span>
			</label>
		</div>
-		<span class="o-forms-input__state"></span>
+		<span class="o-forms-input__state o-forms-input__state--custom">
+			Processing
+		</span>
	</span>
</div>
```

We recommend users call `setState` rather than construct state
markup themselves. It has been updated to use this new markup.
Its third argument `iconOnly` is now an options map which includes
a setting for `iconOnly` and `iconLabel`, so the label may be
customsied.