### PR TITLE
Fix checked and disabled styles on checkboxes with extra content.

### DIFF
--- a/demos/src/data/checkboxes.json
+++ b/demos/src/data/checkboxes.json
@@ -226,6 +226,13 @@
 				{
 					"type": "checkbox",
 					"name": "extra",
+					"value": "This is a disabled checkbox with extra content.",
+					"additionalContent": "Here is the extra content for this checkbox.",
+					"disabled": true
+				},
+				{
+					"type": "checkbox",
+					"name": "extra",
 					"value": "By submitting this form, you indicate your consent to also being contacted by the Financial Times by email. post or phone about our other products, services or special offers unless you untick this box. You can change your preferences anytime in the My Account section.",
 					"checked": true
 				}

--- a/src/scss/shared/_control-inputs.scss
+++ b/src/scss/shared/_control-inputs.scss
@@ -6,7 +6,7 @@
 	width: $_o-forms-spacing-six;
 	height: $_o-forms-spacing-six;
 
-	&:checked + .o-forms-input__label:after {
+	&:checked ~ .o-forms-input__label:after {
 		opacity: 1;
 	}
 
@@ -14,7 +14,7 @@
 		&:disabled {
 			opacity: 0;
 
-			+ .o-forms-input__label {
+			~ .o-forms-input__label {
 				opacity: 0.4;
 			}
 		}


### PR DESCRIPTION
## Problems
When using a checkbox that has extra content (i.e. more than one `<span class="o-forms-input__label">`), there are two issues:

1) Clicking on either the label or the checkbox does not visibly check the checkbox. The field will be marked as checked in the DOM, but it just won't be visually apparent. This issue can be seen on the [Checkboxes demo for `o-forms` version `8.0.0`](https://registry.origami.ft.com/components/o-forms@8.0.0#demo-checkboxes) under "Checkboxes with extra content."
2) When disabled, only the first label for the checkbox would have the disabled styling applied. Also, the checkbox would not have the disabled styling.

I've only checked in Chrome and Firefox, but the issue occurs in both.

This is happening because each bit of content in the label has its own checkbox displayed via the psuedo elements, and they all sit on top of one another. By using an _adjacent_ sibling selector (`+`), the checked and disabled styling is only applied to the psuedo element for the first bit of content in the label, which is being hidden by the psuedo elements for the other bits of content.

## Solution
To fix this issue, I've used a _general_ sibling selector (`~`) instead so that all content in the label has the styling applied, rather than just the first bit of content.

I've also added an additional checkbox to the demo to make sure that the disabled styling is applied when there is extra content in the label. I'm not precious about that staying in there though, just thought it may be useful.

## Screenshots

**Before**
![checkboxes-extra-content-before](https://user-images.githubusercontent.com/6975428/70183396-9e70d680-16dd-11ea-9477-1a044281ad91.gif)

**After**
![checkboxes-extra-content-after](https://user-images.githubusercontent.com/6975428/70183410-a7fa3e80-16dd-11ea-9eaf-b678c3f70199.gif)
