### PR TITLE
Output custom form icon base styles only once.

### DIFF
--- a/src/scss/modifiers/_custom.scss
+++ b/src/scss/modifiers/_custom.scss
@@ -42,7 +42,7 @@
 		min-width: unset;
 	}
 
-	a.o-forms-input__link--current, // sass-lint:disable-line no-qualifying-elements
+	a.o-forms-input__link.o-forms-input__link--current, // sass-lint:disable-line no-qualifying-elements
 	input[type=radio]:checked + .o-forms-input__label { // sass-lint:disable-line no-qualifying-elements
 		&:after {
 			display: block;
@@ -55,7 +55,6 @@
 /// @param {String} $input Type of input to set icons on ('anchor' or radio)
 /// @param {Map|null} $theme Custom theme map
 @mixin _oFormsCustomIcon($icon, $input, $theme: null) {
-	@include _oFormsCustomIconBase();
 	$theme: _oFormsThemeToBrandVariants($theme);
 	$element: '';
 
@@ -134,6 +133,7 @@
 	}
 
 	@if $icons {
+		@include _oFormsCustomIconBase();
 		@each $icon in $icons {
 			@include _oFormsCustomIcon($icon, $input, $theme);
 		}


### PR DESCRIPTION
Also make the `o-forms-input__link--current` more specific.

Source order seems to be behind the icon appearing white on myft:
![70637531-4a12ad00-1c2f-11ea-85b5-a812bb15beac](https://user-images.githubusercontent.com/10405691/70646845-a8e02280-1c3f-11ea-847c-ebb8de90b6ab.png)
