### PR TITLE
Position state and error elements against inputs when labels are long.

### DIFF
--- a/demos/src/data/radio-box.json
+++ b/demos/src/data/radio-box.json
@@ -174,14 +174,14 @@
 			"field": {
 				"type": "radio-box",
 				"aria": {
-					"label": "saving-state-group-title",
-					"info": "saving-state-group-info"
+					"label": "saving-state-group-title-long",
+					"info": "saving-state-group-info-long"
 				},
 				"modifiers": ["saving"],
 				"state": "Saving"
 			},
 			"title": {
-				"main": "Inline box-style radio buttons",
+				"main": "Inline box-style radio buttons with very long title. Inline box-style radio buttons with very long title",
 				"prompt": "With a stacked saving state"
 			},
 			"inputs": [

--- a/demos/src/multiple-input-field.mustache
+++ b/demos/src/multiple-input-field.mustache
@@ -26,7 +26,7 @@
 			{{#info}}aria-describedby="{{info}}"{{/info}}
 		{{/field.aria}}>
 
-		<span class="o-forms-title">
+		<span class="o-forms-title{{#title.modifiers}} o-forms-title--{{.}}{{/title.modifiers}}">
 			<span class="o-forms-title__main" id="{{field.aria.label}}">{{title.main}}</span>
 			{{#title.prompt}}
 				<span class="o-forms-title__prompt" {{#field.aria.info}} id={{field.aria.info}} {{/field.aria.info}}>{{.}}</span>

--- a/src/scss/_radio-box.scss
+++ b/src/scss/_radio-box.scss
@@ -49,17 +49,17 @@
 		@include oGridRespondTo(S) {
 			&.o-forms-input--inline .o-forms-input__state {
 				position: relative;
-				bottom: 0;
+				margin-bottom: 0;
 			}
 		}
 
 		.o-forms-input__state {
-			position: absolute;
-			bottom: -($_o-forms-spacing-five + $_o-forms-spacing-half);
+			position: relative;
+			margin-bottom: -($_o-forms-spacing-five + $_o-forms-spacing-half);
 		}
 
 		.o-forms-input__error {
-			bottom: -$_o-forms-spacing-four;
+			margin-bottom: -$_o-forms-spacing-four;
 		}
 	}
 }

--- a/src/scss/_radio-box.scss
+++ b/src/scss/_radio-box.scss
@@ -59,6 +59,7 @@
 		}
 
 		.o-forms-input__error {
+			margin-top: 0;
 			margin-bottom: -$_o-forms-spacing-four;
 		}
 	}

--- a/src/scss/shared/_validity.scss
+++ b/src/scss/shared/_validity.scss
@@ -34,8 +34,8 @@
 			);
 			color: _oFormsGet('invalid-base');
 			display: block;
-			position: absolute;
-			bottom: -$_o-forms-spacing-five;
+			position: relative;
+			margin-bottom: -$_o-forms-spacing-five;
 		}
 	}
 }

--- a/src/scss/shared/_validity.scss
+++ b/src/scss/shared/_validity.scss
@@ -35,6 +35,7 @@
 			color: _oFormsGet('invalid-base');
 			display: block;
 			position: relative;
+			margin-top: $_o-forms-spacing-one;
 			margin-bottom: -$_o-forms-spacing-five;
 		}
 	}


### PR DESCRIPTION
When a label and input are inline, with label to the left and
input to the right, the state/error element is positioned on
the right under the input. If the label is long the status/error
message is pushed down away from the input due to absolute
positioning against their shared container.

![71660670-b6229580-2d43-11ea-8b1c-d2bd06d21d12](https://user-images.githubusercontent.com/10405691/71899631-0dfe3980-3154-11ea-8a67-547e6c9f588d.png)

Absolute positioning is used with a negative bottom value so the
state does not push content down the page when added dynamically.
The state sits within the fields margin instead. We can use
relative positioning and a negative margin instead. This keeps
the state close to the input when the label becomes long, but also
allows the state to avoid pushing other page content down by
negating the containers margin.

<img width="508" alt="Screenshot 2020-01-07 at 13 29 54" src="https://user-images.githubusercontent.com/10405691/71899654-15254780-3154-11ea-9165-a91bc6e7d1a1.png">
<img width="499" alt="Screenshot 2020-01-07 at 13 30 38" src="https://user-images.githubusercontent.com/10405691/71899655-15254780-3154-11ea-8a67-866a29d2e45c.png">

Relates to: #304



(Also fix "vertical centered inline radio box" demo.)