### PR TITLE
Show invalid inputs with missing ids in the error summary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,11 +456,11 @@ In order to provide customised error messages for an invalid input field, you'll
 The message is hidden by default, until the input field becomes invalid.
 
 #### Error Summary
-`o-forms` also generates an error message element when a form is submitted and invalid inputs are recognised.
+`o-forms` also generates an error message element when a form is submitted and invalid inputs are recognised. Inputs must have a unique id and a field title element to show in the error summary.
 
 This feature will collect the custom messages of the invalid fields if they are present in the markup, or will default to the browsers native error message if they aren't. It will associate the message to the title of the input that is invalid, generate a list of links at the top of the form, and focus on the first link.
 
-This markup will always be generated dynamically if the [errorSummary option](#form-instance) is set to `true`.
+This markup will always be generated dynamically if the [errorSummary option](#form-instance) is not set to `false`.
 
 ## Sass
 `o-forms` has a primary mixin; `oForms()`.

--- a/demos/src/interactive.mustache
+++ b/demos/src/interactive.mustache
@@ -64,6 +64,28 @@
 		</span>
 	</label>
 
+	<!-- with no id the error summary can not link to this -->
+	<label class="o-forms-field">
+		<span class="o-forms-title">
+			<span class="o-forms-title__main">Text input with missing id attribute to link to</span>
+			<span class="o-forms-title__prompt">prompt text</span>
+		</span>
+
+		<span class="o-forms-input o-forms-input--text">
+			<input type="text" name="required-no-id" value="" required>
+		</span>
+	</label>
+
+	<!-- with no o-forms-title this is not able to show in the error summary -->
+	<div class="o-forms-field">
+		<span class="o-forms-input o-forms-input--checkbox">
+			<label>
+				<input id="my-single-checkbox" type="checkbox" name="my-single-checkbox" required/>
+				<span class="o-forms-input__label">I accept these terms.</span>
+			</label>
+		</span>
+	</div>
+
   	<input id="hidden-demo" name="hidden-demo" type="hidden" value="123">
 
 	<button class="o-buttons o-buttons--secondary" type="submit">Let's get started</button>

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -89,7 +89,10 @@ class Forms {
 					} else {
 						this.summary = this.form.insertBefore(new ErrorSummary(checkedElements), this.form.firstElementChild);
 					}
-					this.summary.querySelector('a').focus();
+					const firstErrorAnchor = this.summary.querySelector('a');
+					if (firstErrorAnchor) {
+						firstErrorAnchor.focus();
+					}
 				}
 
 				return;
@@ -103,19 +106,24 @@ class Forms {
 	* Form validation
 	* Validates every element in the form and creates input objects for the error summary
 	*/
-	validateFormInputs () {
-		return this.formInputs.map(element => {
-			let valid = element.validate();
-			let input = element.input;
+	validateFormInputs() {
+		return this.formInputs.map(oFormInput => {
+			let valid = oFormInput.validate();
+			let input = oFormInput.input;
 			let field = input.closest('.o-forms-field');
-			let label = field ? field.querySelector('.o-forms-title__main').innerHTML : null;
+			let labelElement = field ? field.querySelector('.o-forms-title__main') : null;
+			// label is actually the field title, not for example the label of a single checkbox.
+			// this is used to generate an error summary
+			let label = labelElement ? labelElement.textContent : null;
 			let errorElement = field ? field.querySelector('.o-forms-input__error') : null;
-			let error = errorElement ? errorElement.innerHTML : input.validationMessage;
+			let error = errorElement ? errorElement.textContent : input.validationMessage;
 			return {
 				id: input.id,
 				valid,
 				error: !valid ? error : null,
-				label
+				label,
+				field,
+				element: oFormInput.input
 			};
 		});
 	}

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -70,14 +70,14 @@ describe('Forms', () => {
 				submit.click();
 				summary = formEl.querySelector('.o-forms__error-summary');
 				listItems = summary.querySelectorAll('a');
-				proclaim.equal(listItems.length, 4);
+				proclaim.equal(listItems.length, 2);
 			});
 
 			it('the summary gets updated on second submit if a form field has been amended', () => {
 				submit.click();
 				summary = formEl.querySelector('.o-forms__error-summary');
 				listItems = summary.querySelectorAll('a');
-				proclaim.equal(listItems.length, 4);
+				proclaim.equal(listItems.length, 2);
 
 				textInput = formEl.elements['text'];
 				textInput.value = 'something';
@@ -85,7 +85,7 @@ describe('Forms', () => {
 				submit.click();
 				summary = formEl.querySelector('.o-forms__error-summary');
 				listItems = summary.querySelectorAll('a');
-				proclaim.equal(listItems.length, 3);
+				proclaim.equal(listItems.length, 1);
 			});
 
 			it('does not error if there is no field title for an input', () => {

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -87,6 +87,31 @@ describe('Forms', () => {
 				listItems = summary.querySelectorAll('a');
 				proclaim.equal(listItems.length, 3);
 			});
+
+			it('does not error if there is no field title for an input', () => {
+				// Add a form with a single checkbox, which has no field title.
+				const singleCheckboxFormString = `
+				<form action="" id="single-checkbox-form">
+					<div class="o-forms-field">
+						<span class="o-forms-input o-forms-input--checkbox">
+							<label>
+								<input id="my-single-checkbox" type="checkbox" name="my-single-checkbox" required/>
+								<span class="o-forms-input__label">I accept these terms.</span>
+							</label>
+						</span>
+					</div>
+					<input class="o-buttons o-buttons--secondary" type="submit">
+				</form>
+			`;
+				const range = document.createRange();
+				const formDocumentFragment = range.createContextualFragment(singleCheckboxFormString);
+				document.body.appendChild(formDocumentFragment);
+				const singleCheckboxFormEl = document.getElementById('single-checkbox-form');
+				const singleCheckboxFormSubmitEl = singleCheckboxFormEl.querySelector('[type="submit"]');
+				// initialise and submit the form, with no error
+				new Forms(singleCheckboxFormEl);
+				singleCheckboxFormSubmitEl.click();
+			});
 		});
 
 		context('`opts.errorSummary = false`', () => {


### PR DESCRIPTION
Warn in the console that the error summary cannot link to an input
with no id. This is better than not showing the user the error
in the summary at all. I considered generating an id but thought
it may risk collisions, or users attempting to hang logic from
dynamic ids which may change.

Also warn in the console if the error summary is enabled but an
invalid input does not have a field title to show in the error
summary. For example, using the label of a single checkbox
"I accept these terms." would not make sense in an error summary;
the developer should add a field title like "terms and conditions"
if they would also like to use the error summary with such an input.