### PR TITLE
fix: update form.summary with new element

### DIFF
--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -85,7 +85,9 @@ class Forms {
 			if (checkedElements.some(input => input.valid === false)) {
 				if (this.opts.errorSummary) {
 					if (this.summary) {
-						this.summary = this.form.replaceChild(new ErrorSummary(checkedElements), this.summary);
+						const newSummary = new ErrorSummary(checkedElements);
+						this.form.replaceChild(newSummary, this.summary);
+						this.summary = newSummary;
 					} else {
 						this.summary = this.form.insertBefore(new ErrorSummary(checkedElements), this.form.firstElementChild);
 					}


### PR DESCRIPTION
Upon re-submitting a form with invalid elements that is already showing a summary, the replacement of the previous summary wasn't updating the DOM reference. This lead to an error when attempting to replace the summary as the stored reference was no longer within the DOM tree. This meant we would receive:

```
Uncaught DOMException: Failed to execute 'replaceChild' on 'Node': The node to be replaced is not a child of this node.
```

