### PR TITLE
Prevent errors inlining on inputs with a suffix element

### DIFF
--- a/src/scss/shared/_single-inputs.scss
+++ b/src/scss/shared/_single-inputs.scss
@@ -54,5 +54,9 @@
 			flex: 1;
 			margin-right: $_o-forms-spacing-two;
 		}
+
+		.o-forms-input__error {
+			width: 100%;
+		}
 	}
 }


### PR DESCRIPTION
Small fix to prevent the inlining of flex children of a `o-forms-input--suffix` parent. See example below:
![Screenshot 2020-01-22 at 11 14 01](https://user-images.githubusercontent.com/7748470/72911161-83abfd00-3d31-11ea-97c1-3bfb7003623e.png)