### PR TITLE
Document other required polyfills.

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -22,7 +22,9 @@
 		"required": [
 			"DOMTokenList",
 			"Element.prototype.closest",
-			"Array.prototype.includes"
+			"Array.prototype.includes",
+			"Array.from",
+			"Object.assign"
 		]
 	},
 	"demosDefaults": {


### PR DESCRIPTION
These polyfills are already required by o-forms (so this isn't
a breaking change). As our users are already including these
polyfills I don't think we have to release a patch that removes
these features -- but they should be documented for the future.