### PR TITLE
Fix select input arrow position in IE11

### DIFF
--- a/src/scss/_select.scss
+++ b/src/scss/_select.scss
@@ -22,7 +22,7 @@
 			@include oIconsContent('arrow-down', _oFormsGet('field-standard-text'), $size: null, $include-base-styles: false);
 			appearance: none;
 			background-repeat: no-repeat;
-			background-size: auto $_o-forms-spacing-six;
+			background-size: $_o-forms-spacing-six $_o-forms-spacing-six;
 			border-radius: 0;
 			background-clip: padding-box;
 			color: _oFormsGet('default-text');
@@ -30,13 +30,10 @@
 			outline: none;
 
 			// For iOS 6 that doesn't support 4-value background-position
-			// Handles background sizing and positioning issues with IE10+
-			// sass-lint:disable no-duplicate-properties no-vendor-prefixes no-misspelled-properties
+			// sass-lint:disable no-duplicate-properties
 			background-position: right center;
 			background-position: right $_o-forms-spacing-two center;
-			-ms-background-position-x: right -75%;
-			-ms-background-position-y: center;
-			// sass-lint:enable no-duplicate-properties no-vendor-prefixes no-misspelled-properties
+			// sass-lint:enable no-duplicate-properties
 
 			// Hide stock browser arrow in IE 10+
 			// sass-lint:disable no-vendor-prefixes


### PR DESCRIPTION
>If you only set one dimension using background-size and the other
>to auto, IE will choose the aspect ratio of the element rather
>than the intrinsic dimensions of the SVG graphic.

https://thatemil.com/blog/2015/03/15/sizing-svg-background-images-in-internet-explorer/

Fixes: https://github.com/Financial-Times/o-forms/issues/318

![Screenshot 2020-02-13 at 17 40 15](https://user-images.githubusercontent.com/10405691/74462700-90cb9000-4e88-11ea-9c5e-a4bdeeb69f0d.png)
