### PR TITLE
Use `inputmode="numeric"` for date inputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,25 +385,28 @@ For this you'll need to add the `o-forms-field--inverse` to the parent element:
 Date inputs and anchor elements with box-like styling are outliers to the rules above.
 
 #### Date inputs
-We do not use `input[type=date]`, but instead combine three `input[type=text]` within the [base structure for a multiple input field](#multiple-input-fields), as shown below:
+We do not use `input[type=date]`, but instead combine three `input[type=text]` within the [base structure for a multiple input field](#multiple-input-fields). We use `inputmode="numeric"` to show a numeric keyboard in mobile browsers which support the attribute. And use a `pattern` attribute for basic client side date validation. As shown below:
 ```html
 ...
 	<span class="o-forms-input o-forms-input--date">
 		<label>
-			<input class="o-forms-input__day-part" type="text" pattern="0[1-9]|[12]\d|3[01]" name="my-date"/>
+			<input class="o-forms-input__day-part" type="text" inputmode="numeric" pattern="0[1-9]|[12]\d|3[01]" name="my-date"/>
 			<span class="o-forms-input__label">DD</span>
 		</label>
 		<label>
-			<input class="o-forms-input__month-part" type="text" pattern="0?[1-9]|1[012]" name="my-date"/>
+			<input class="o-forms-input__month-part" type="text" inputmode="numeric" pattern="0?[1-9]|1[012]" name="my-date"/>
 			<span class="o-forms-input__label">MM</span>
 		</label>
 		<label>
-			<input class="o-forms-input__year-part" type="text" pattern="[0-9]{4}" name="my-date"/>
+			<input class="o-forms-input__year-part" type="text" inputmode="numeric" pattern="[0-9]{4}" name="my-date"/>
 			<span class="o-forms-input__label">YYYY</span>
 		</label>
 	</span>
 ...
 ```
+
+We avoid `type="number"` here for a number of reasons related to accessibility and how browsers handle number inputs, which [gov.uk explain thoroughly in a blogpost](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/).
+
 [_See the full markup for date inputs in the registry_](https://registry.origami.ft.com/components/o-forms#date)
 
 #### Pseudo Radio Links

--- a/demos/src/data/date.json
+++ b/demos/src/data/date.json
@@ -19,6 +19,7 @@
 					"name": "date",
 					"pattern":"0[1-9]|[12]\\d|3[01]",
 					"classes": "o-forms-input__day-part",
+					"inputmode": "numeric",
 					"date": "DD"
 				},
 				{
@@ -51,6 +52,7 @@
 					"name": "disabled-date",
 					"pattern":"0[1-9]|[12]\\d|3[01]",
 					"classes": "o-forms-input__day-part",
+					"inputmode": "numeric",
 					"date": "DD",
 					"disabled": true
 				},
@@ -59,6 +61,7 @@
 					"name": "disabled-date",
 					"pattern": "0?[1-9]|1[012]",
 					"classes": "o-forms-input__month-part",
+					"inputmode": "numeric",
 					"date": "MM",
 					"disabled": true
 				},
@@ -67,6 +70,7 @@
 					"name": "disabled-date",
 					"pattern": "[0-9]{4}",
 					"classes": "o-forms-input__year-part",
+					"inputmode": "numeric",
 					"date": "YYYY",
 					"disabled": true
 				}
@@ -92,6 +96,7 @@
 					"name": "invalid-date",
 					"pattern":"0[1-9]|[12]\\d|3[01]",
 					"classes": "o-forms-input__day-part",
+					"inputmode": "numeric",
 					"date": "DD",
 					"value": "01"
 				},
@@ -100,6 +105,7 @@
 					"name": "invalid-date",
 					"pattern": "0?[1-9]|1[012]",
 					"classes": "o-forms-input__month-part",
+					"inputmode": "numeric",
 					"date": "MM",
 					"value": "24"
 				},
@@ -108,6 +114,7 @@
 					"name": "invalid-date",
 					"pattern": "[0-9]{4}",
 					"classes": "o-forms-input__year-part",
+					"inputmode": "numeric",
 					"date": "YYYY",
 					"value": "2019"
 				}
@@ -131,6 +138,7 @@
 					"name": "inline-date",
 					"pattern":"0[1-9]|[12]\\d|3[01]",
 					"classes": "o-forms-input__day-part",
+					"inputmode": "numeric",
 					"date": "DD"
 				},
 				{

--- a/demos/src/multiple-input-field.mustache
+++ b/demos/src/multiple-input-field.mustache
@@ -44,6 +44,7 @@
 						name="{{name}}"
 						value="{{value}}"
 						{{#classes}}class={{.}}{{/classes}}
+						{{#inputmode}}inputmode="{{.}}"{{/inputmode}}
 						{{#pattern}}pattern={{.}}{{/pattern}}
 						aria-label="{{#date}}{{date}}{{/date}}{{^date}}{{value}}{{/date}}"
 						{{#checked}}checked{{/checked}}

--- a/demos/src/single-input-field.mustache
+++ b/demos/src/single-input-field.mustache
@@ -1,6 +1,6 @@
 {{#variants}}
 	<label class="o-forms-field{{#inline-field}} o-forms-field--inline{{/inline-field}}{{#optional}} o-forms-field--optional{{/optional}}">
-		
+
 		<span	class="o-forms-title{{#title.modifiers}} o-forms-title--{{.}}{{/title.modifiers}}">
 			<span class="o-forms-title__main">{{title.main}}</span>
 			{{#title.prompt}}<span class="o-forms-title__prompt">{{.}}</span>{{/title.prompt}}
@@ -9,22 +9,26 @@
 		<span class="o-forms-input o-forms-input--{{input.type}}{{#input.modifiers}} o-forms-input--{{.}}{{/input.modifiers}}">
 
 			{{#textInput}}
-				<input 
-					type="{{input.type}}" 
-					name="text" 
-					value="{{input.value}}" 
+				<input
+					type="{{input.type}}"
+					name="text"
+					value="{{input.value}}"
+					{{#inputmode}}inputmode="{{.}}"{{/inputmode}}
+					{{#pattern}}pattern={{.}}{{/pattern}}
 					{{#disabled}}disabled{{/disabled}}
 					{{^disabled}}{{^optional}}required{{/optional}}{{/disabled}}>
 			{{/textInput}}
-			
+
 			{{#textArea}}
-				<textarea 
+				<textarea
+					{{#inputmode}}inputmode="{{.}}"{{/inputmode}}
+					{{#pattern}}pattern={{.}}{{/pattern}}
 					{{#disabled}}disabled{{/disabled}}
 					{{^disabled}}{{^optional}}required{{/optional}}{{/disabled}}>{{input.value}}</textarea>
 			{{/textArea}}
 
 			{{#select}}
-				<select 
+				<select
 					{{#multiple}}multiple{{/multiple}}
 					{{#disabled}}disabled{{/disabled}}
 					{{^disabled}}{{^optional}}required{{/optional}}{{/disabled}}>
@@ -36,6 +40,6 @@
 			{{#input.error}}<span class="o-forms-input__error">{{.}}</span>{{/input.error}}
 			{{#input.button}}<button class="{{.}}">Go</button>{{/input.button}}
 		</span>
-	
+
 	</label>
 {{/variants}}


### PR DESCRIPTION
This shows a numeric keypad in supporting browsers.

Before:
<img width="374" alt="Screenshot 2020-02-27 at 14 46 49" src="https://user-images.githubusercontent.com/10405691/75455244-2c70fc00-5971-11ea-9fff-ad5cdea691a7.png">

After:
<img width="364" alt="Screenshot 2020-02-27 at 14 46 11" src="https://user-images.githubusercontent.com/10405691/75455265-309d1980-5971-11ea-83a5-a536cc00a769.png">

