### PR TITLE
Remove default browser styles.

### DIFF
--- a/src/scss/shared/_base.scss
+++ b/src/scss/shared/_base.scss
@@ -47,5 +47,10 @@
 
 	.o-forms-input {
 		margin-top: $_o-forms-spacing-three;
+		// remove default browser styles
+		input {
+			border-radius: 0;
+			appearance: none;
+		}
 	}
 }


### PR DESCRIPTION
E.g. we do not want a drop shadow or border radius in mobile Safari

Before 😱:
<img width="374" alt="Screenshot 2020-02-27 at 15 00 29" src="https://user-images.githubusercontent.com/10405691/75456228-2a5b6d00-5972-11ea-96eb-6e9382fbeb09.png">

After:
<img width="374" alt="Screenshot 2020-02-27 at 15 01 18" src="https://user-images.githubusercontent.com/10405691/75456234-2af40380-5972-11ea-8c0d-9be40967fabb.png">
