### PR TITLE
Correct toggle spacing so the label is not obscured.

### DIFF
--- a/src/scss/_toggle.scss
+++ b/src/scss/_toggle.scss
@@ -3,9 +3,10 @@
 /// @output styles for toggle based on a checkbox input
 @mixin _oFormsToggle($disabled: null) {
 	.o-forms-input--toggle {
+		$toggle-width: $_o-forms-spacing-ten;
 		.o-forms-input__label {
 			display: inline-block;
-			padding: $_o-forms-spacing-half 0 $_o-forms-spacing-half $_o-forms-spacing-eight;
+			padding: $_o-forms-spacing-half 0 $_o-forms-spacing-half #{$toggle-width + $_o-forms-spacing-one};
 			vertical-align: top;
 
 			&:before,
@@ -21,7 +22,7 @@
 				background-color: _oFormsGet('toggle');
 				border-radius: $_o-forms-spacing-ten;
 				height: $_o-forms-spacing-six;
-				width: $_o-forms-spacing-ten;
+				width: $toggle-width;
 			}
 
 			&:after {
@@ -36,9 +37,6 @@
 		}
 
 		input[type=checkbox] { // sass-lint:disable-line no-qualifying-elements
-			position: relative;
-			left: $_o-forms-spacing-three;
-
 			&:checked + .o-forms-input__label {
 				&:before {
 					background-color: _oFormsGet('toggle-selected');


### PR DESCRIPTION
Default browser styles were removed in the last commit but
o-forms toggles relied on hidden checkbox dimensions for
layout.

before:
<img width="214" alt="Screenshot 2020-02-27 at 16 34 29" src="https://user-images.githubusercontent.com/10405691/75464559-474a6d00-597f-11ea-9822-64ac3a0ba8f8.png">

after:
<img width="240" alt="Screenshot 2020-02-27 at 16 36 50" src="https://user-images.githubusercontent.com/10405691/75464628-5df0c400-597f-11ea-8654-d9cfc61e4330.png">
