### PR TITLE
Correct toggle spacing so the label is not obscured.

### DIFF
--- a/src/scss/_toggle.scss
+++ b/src/scss/_toggle.scss
@@ -3,9 +3,10 @@
 /// @output styles for toggle based on a checkbox input
 @mixin _oFormsToggle($disabled: null) {
 	.o-forms-input--toggle {
+		$toggle-width: $_o-forms-spacing-ten;
 		.o-forms-input__label {
 			display: inline-block;
-			padding: $_o-forms-spacing-half 0 $_o-forms-spacing-half $_o-forms-spacing-eight;
+			padding: $_o-forms-spacing-half 0 $_o-forms-spacing-half #{$toggle-width + $_o-forms-spacing-one};
 			vertical-align: top;
 
 			&:before,
@@ -21,7 +22,7 @@
 				background-color: _oFormsGet('toggle');
 				border-radius: $_o-forms-spacing-ten;
 				height: $_o-forms-spacing-six;
-				width: $_o-forms-spacing-ten;
+				width: $toggle-width;
 			}
 
 			&:after {
@@ -36,9 +37,6 @@
 		}
 
 		input[type=checkbox] { // sass-lint:disable-line no-qualifying-elements
-			position: relative;
-			left: $_o-forms-spacing-three;
-
 			&:checked + .o-forms-input__label {
 				&:before {
 					background-color: _oFormsGet('toggle-selected');


### PR DESCRIPTION
Default browser styles were removed in the last commit but
o-forms toggles relied on hidden checkbox dimensions for
layout.

before/after
<img width="214" alt="Screenshot 2020-02-27 at 16 34 29" src="https://user-images.githubusercontent.com/10405691/75467482-a14d3180-5983-11ea-8bb3-8d94cce735fc.png">
<img width="225" alt="Screenshot 2020-02-27 at 16 39 04" src="https://user-images.githubusercontent.com/10405691/75467483-a1e5c800-5983-11ea-985d-6a22b7a10d11.png">
