### PR TITLE
Ensure Safari uses the correct text colour for disabled inputs.

### DIFF
--- a/src/scss/shared/_single-inputs.scss
+++ b/src/scss/shared/_single-inputs.scss
@@ -24,6 +24,11 @@
 		color: _oFormsGet('disabled-text');
 		background-color: _oFormsGet('disabled-base');
 		border-color: _oFormsGet('disabled-base');
+		// Ensure Safari uses the correct text colour
+		// for disabled inputs.
+		// sass-lint:disable no-vendor-prefixes
+		-webkit-text-fill-color: currentColor;
+		// sass-lint:enable no-vendor-prefixes
 	}
 }
 


### PR DESCRIPTION
before/after
<img width="365" alt="Screenshot 2020-04-01 at 10 36 57" src="https://user-images.githubusercontent.com/10405691/78122662-fbb73300-7404-11ea-8a52-12b3180a91ff.png">
