### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -1,7 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 import formFixture from './helpers/fixtures';
 import Forms from './../main';
 

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -1,7 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 import formFixture from './helpers/fixtures';
 import Input from '../src/js/input';
 

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim */
 
-import proclaim from 'proclaim';
 import formFixture from './helpers/fixtures';
 import State from '../src/js/state';
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.