### PR TITLE
Set `min-width: 0` for inputs with a suffix.

### DIFF
--- a/src/scss/shared/_single-inputs.scss
+++ b/src/scss/shared/_single-inputs.scss
@@ -57,6 +57,10 @@
 
 		#{$element} {
 			flex: 1;
+			// Allow form inputs with a suffix to shrink fully,
+			// regardless of the input `size` attribute.
+			// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#htmlattrdefsize
+			min-width: 0;
 			margin-right: $_o-forms-spacing-two;
 		}
 


### PR DESCRIPTION
Allow form inputs with a suffix to shrink fully, regardless of the
input `size` attribute.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#htmlattrdefsize