### PR TITLE
Place error summary items within an `li` list element.

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ The `$opts` map accepts two lists with the following options:
 	- `'small'`
 	- `'state'`
 	- `'suffix'`
+	- `error-summary`
 
 _Note 1: `valid` and `invalid` styles are output with the base of `o-forms` so there is no need to include them in the list above._
 

--- a/src/js/error-summary.js
+++ b/src/js/error-summary.js
@@ -83,7 +83,8 @@ class ErrorSummary {
 		// Return a error summary item which links to the input if an id exists.
 		if (input.id) {
 			const itemAnchor = ErrorSummary.createAnchor(input);
-			return item.appendChild(itemAnchor);
+			item.appendChild(itemAnchor);
+			return item;
 		}
 		// If no id exist return an error summary item without a link.
 		console.warn(`Could not link to an invalid input from the error summary. ` +

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -65,17 +65,17 @@ describe('Forms', () => {
 				proclaim.isNotNull(summary);
 			});
 
-			it('the summary reflects the number of invalid inputs', () => {
+			it('the summary reflects the number of invalid inputs as list items with links', () => {
 				submit.click();
 				summary = formEl.querySelector('.o-forms__error-summary');
-				listItems = summary.querySelectorAll('a');
+				listItems = summary.querySelectorAll('li > a');
 				proclaim.equal(listItems.length, 2);
 			});
 
 			it('the summary gets updated on second submit if a form field has been amended', () => {
 				submit.click();
 				summary = formEl.querySelector('.o-forms__error-summary');
-				listItems = summary.querySelectorAll('a');
+				listItems = summary.querySelectorAll('li > a');
 				proclaim.equal(listItems.length, 2);
 
 				textInput = formEl.elements['text'];
@@ -83,7 +83,7 @@ describe('Forms', () => {
 
 				submit.click();
 				summary = formEl.querySelector('.o-forms__error-summary');
-				listItems = summary.querySelectorAll('a');
+				listItems = summary.querySelectorAll('li > a');
 				proclaim.equal(listItems.length, 1);
 			});
 


### PR DESCRIPTION
`appendChild` returns the appended child, not the parent. This
caused a bug where anchor tags were being placed within a `ul`
unordered list element of errors.