### PR TITLE
Make sure disabled text inputs have an opacity of 1.

### DIFF
--- a/src/scss/shared/_single-inputs.scss
+++ b/src/scss/shared/_single-inputs.scss
@@ -29,6 +29,8 @@
 		// sass-lint:disable no-vendor-prefixes
 		-webkit-text-fill-color: currentColor;
 		// sass-lint:enable no-vendor-prefixes
+		// iOS Safari has a default opacity of 0.4
+		opacity: 1;
 	}
 }
 


### PR DESCRIPTION
In iOS Safari they were displaying with an opacity of 0.4. Fixes https://github.com/Financial-Times/o-forms/issues/347