### PR TITLE
Also fix the inputs on the radio boxes

### DIFF
--- a/src/scss/_radio-box.scss
+++ b/src/scss/_radio-box.scss
@@ -36,7 +36,13 @@
 
 		input[type=radio] { // stylelint-disable-line selector-no-qualifying-type
 			position: absolute;
+			// Hide visually while remaining accessible to voice control like Dragon
+			// Dragon requires the input it is trying to click to be actually clickable
 			opacity: 0;
+			z-index: 1;
+			width: 100%;
+			height: 100%;
+			cursor: pointer;
 
 			@if $disabled {
 				&:disabled + .o-forms-input__label { // stylelint-disable-line selector-no-qualifying-type


### PR DESCRIPTION
following on from this: https://github.com/Financial-Times/o-forms/pull/352

@taraojo has pointed out that the `_oFormsControlsBase` mixin isn't used in the box-styled radio inputs!

i've added it here directly, but maybe we should also open an issue about getting the box-styled ones to actually use that mixin? because as @taraojo also points out, the comment on the mixin actually mentions box-style radios