### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/interactive.js
+++ b/demos/src/interactive.js
@@ -1,4 +1,4 @@
-import Forms from '../../src/js/forms.js';
+import Forms from '../../src/js/forms.js.js';
 
 const formEl = document.forms[0];
 const form = new Forms(formEl);

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import oForms from './src/js/forms';
+import oForms from './src/js/forms.js';
 
 const constructAll = function() {
 	oForms.init();

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -1,6 +1,6 @@
-import Input from './input';
-import State from './state';
-import ErrorSummary from './error-summary';
+import Input from './input.js';
+import State from './state.js';
+import ErrorSummary from './error-summary.js';
 
 class Forms {
 	/**

--- a/test/forms.test.js
+++ b/test/forms.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import formFixture from './helpers/fixtures';
-import Forms from './../main';
+import formFixture from './helpers/fixtures.js';
+import Forms from './../main.js';
 
 describe('Forms', () => {
 	let formEl;

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import formFixture from './helpers/fixtures';
-import Input from '../src/js/input';
+import formFixture from './helpers/fixtures.js';
+import Input from '../src/js/input.js';
 
 describe('Input', () => {
 	let form;

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import formFixture from './helpers/fixtures';
-import State from '../src/js/state';
+import formFixture from './helpers/fixtures.js';
+import State from '../src/js/state.js';
 
 describe('State', () => {
 	let form;


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing