### PR TITLE
Do not style suffix buttons based on validity.

### DIFF
--- a/demos/src/interactive-suffix.mustache
+++ b/demos/src/interactive-suffix.mustache
@@ -1,0 +1,12 @@
+<form action="" data-o-component="o-forms">
+	<label class="o-forms-field">
+		<span class="o-forms-title">
+			<span class="o-forms-title__main">Text input with suffix</span>
+		</span>
+
+		<span class="o-forms-input o-forms-input--text o-forms-input--suffix">
+			<input type="text" name="text" value="" required>
+			<button class="o-buttons o-buttons--secondary o-buttons--big">Go</button>
+		</span>
+	</label>
+</form>

--- a/origami.json
+++ b/origami.json
@@ -114,6 +114,14 @@
 			"js": "demos/src/interactive.js"
 		},
 		{
+			"name": "interactive-suffix",
+			"title": "Interactive form demo with suffice",
+			"template": "/demos/src/interactive-suffix.mustache",
+			"description": "Illustrates validation and state behaviour with form JS on an input with a suffix.",
+			"js": "demos/src/interactive.js",
+			"hidden": true
+		},
+		{
 			"name": "pa11y",
 			"title": "Accessibility testing",
 			"template": "/demos/src/pa11y.mustache",

--- a/src/scss/shared/_validity.scss
+++ b/src/scss/shared/_validity.scss
@@ -2,7 +2,7 @@
 /// @output styles for valid and invalid inputs
 @mixin _oFormsValidityStates() {
 	.o-forms-input--valid {
-		*:valid:not(:disabled) {
+		*:valid:not(button):not(:disabled) {
 			color: _oFormsGet('valid-base');
 			border-color: _oFormsGet('valid-base');
 		}


### PR DESCRIPTION
Fixes: https://github.com/Financial-Times/o-forms/issues/303

[`:valid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid) is targetting `button` since it is a form element.
Ideally I think we'd use a class here BEM style rather than exclude specific elements.