### PR TITLE
Position state and error elements against inputs when labels are long.

### DIFF
--- a/src/scss/_radio-box.scss
+++ b/src/scss/_radio-box.scss
@@ -49,17 +49,18 @@
 		@include oGridRespondTo(S) {
 			&.o-forms-input--inline .o-forms-input__state {
 				position: relative;
-				bottom: 0;
+				margin-bottom: 0;
 			}
 		}
 
 		.o-forms-input__state {
-			position: absolute;
-			bottom: -($_o-forms-spacing-five + $_o-forms-spacing-half);
+			position: relative;
+			margin-bottom: -($_o-forms-spacing-five + $_o-forms-spacing-half);
 		}
 
 		.o-forms-input__error {
-			bottom: -$_o-forms-spacing-four;
+			margin-top: 0;
+			margin-bottom: -$_o-forms-spacing-four;
 		}
 	}
 }

--- a/src/scss/shared/_validity.scss
+++ b/src/scss/shared/_validity.scss
@@ -11,7 +11,7 @@
 	*:invalid {
 		box-shadow: none;
 	}
-	
+
 	.o-forms-input__error {
 		display: none;
 	}
@@ -31,8 +31,9 @@
 			@include oTypographySize($scale: -1);
 			color: _oFormsGet('invalid-base');
 			display: block;
-			position: absolute;
-			bottom: -$_o-forms-spacing-five;
+			position: relative;
+			margin-top: $_o-forms-spacing-one;
+			margin-bottom: -$_o-forms-spacing-five;
 		}
 	}
 }


### PR DESCRIPTION
Backports the fix from v8 to v7:
https://github.com/Financial-Times/o-forms/pull/306