### PR TITLE
Add better error styles for whitelabel brand in inverse mode

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -12,7 +12,11 @@ body {
 
 .demo-inverse {
 	margin-top: 16px;
-	background-color: #262a33;
+	background-color: if(
+		index(('master', 'internal'), oBrandGetCurrentBrand()) != null,
+		oColorsByName('slate'),
+		oColorsByName('black')
+	);
 	padding: 10px;
 
 	.o-forms {

--- a/demos/src/inverse-form-whitelabel.mustache
+++ b/demos/src/inverse-form-whitelabel.mustache
@@ -1,0 +1,111 @@
+<div class="demo-inverse">
+	<form action data-o-component="o-forms">
+	<div class="o-forms__error-summary o-forms__error-summary--inverse" aria-labelledby="my-error-summary" role="alert">
+		<h4 id="my-error-summary" class="o-forms__error-summary__heading">There is a problem</h4>
+		<ul class="o-forms__error-summary__list">
+			<li class="o-forms__error-summary__item">
+				<!-- link to the invalid input -->
+				<a href="#my-date-input">
+					<!-- the name of the invalid input -->
+					<span class="o-forms__error-summary__item-overview">My date input</span>:
+					<!-- a description of what is wrong and how to fix it -->
+					<span class="o-forms__error-summary__item-detail">
+						Please use the format (DD/MM/YYYY)
+					</span>
+				</a>
+			</li>
+		</ul>
+	</div>
+
+		<div class="o-forms-field o-forms-field--optional o-forms-field--inverse" role="group" aria-labelledby="date-group-title">
+			<span class="o-forms-title">
+				<span class="o-forms-title__main" id="date-group-title">Date input</span>
+				<span class="o-forms-title__prompt">Optional prompt text</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--date">
+				<label>
+					<input class="o-forms-input__day-part" id="date" type="text" name="date" value pattern="0[1-9]|[12]\d|3[01]" aria-label="Day (DD)" required>
+					<span class="o-forms-input__label" aria-hidden="true">DD</span>
+				</label>
+				<label>
+					<input class="o-forms-input__month-part" type="text" name="date" value pattern="0?[1-9]|1[012]" aria-label="Month (MM)" required>
+					<span class="o-forms-input__label" aria-hidden="true">MM</span>
+				</label>
+				<label>
+					<input class="o-forms-input__year-part" type="text" name="date" value pattern="[0-9]{4}" aria-label="Year (YYYY)" required>
+					<span class="o-forms-input__label" aria-hidden="true">YYYY</span>
+				</label>
+				<span class="o-forms-input__error">Please fill out this field with the required format (DD/MM/YYYY)</span>
+			</span>
+		</div>
+
+		<div class="o-forms-field o-forms-field--inverse" role="group" aria-labelledby="date-group-title">
+			<span class="o-forms-title" aria-hidden="true">
+				<span class="o-forms-title__main" id="date-group-title">Radio box input</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--radio-box">
+				<div class="o-forms-input--radio-box__container">
+					<label>
+						<input id="radio" type="radio" name="box">
+						<span class="o-forms-input__label" aria-hidden="true">Yes</span>
+					</label>
+					<label>
+						<input type="radio" name="box" checked>
+						<span class="o-forms-input__label o-forms-input__label--negative" aria-hidden="true">No</span>
+					</label>
+				</div>
+			</span>
+		</div>
+
+		<label class="o-forms-field o-forms-field--inverse">
+			<span class="o-forms-title">
+				<span class="o-forms-title__main">Required text input</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--text">
+				<input id="required" type="text" name="text" value required>
+				<span class="o-forms-input__error">Please fill out this field</span>
+			</span>
+		</label>
+
+		<label class="o-forms-field o-forms-field--optional o-forms-field--inverse">
+			<span class="o-forms-title">
+				<span class="o-forms-title__main">Optional text input</span>
+				<span class="o-forms-title__prompt">Optional prompt text</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--text">
+				<input type="text" name="optional" value>
+			</span>
+		</label>
+
+		<!-- with no id the error summary can not link to this -->
+		<label class="o-forms-field o-forms-field--inverse">
+			<span class="o-forms-title">
+				<span class="o-forms-title__main">Text input with missing id attribute to link to</span>
+				<span class="o-forms-title__prompt">prompt text</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--text">
+				<input type="text" name="required-no-id" value required>
+			</span>
+		</label>
+
+		<!-- with no o-forms-title this is not able to show in the error summary -->
+		<div class="o-forms-field o-forms-field--inverse">
+			<span class="o-forms-input o-forms-input--checkbox">
+				<label>
+					<input id="my-single-checkbox" type="checkbox" name="my-single-checkbox" required>
+					<span class="o-forms-input__label">I accept these terms.</span>
+				</label>
+			</span>
+		</div>
+
+		<input id="hidden-demo" name="hidden-demo" type="hidden" value="123">
+
+		<button class="o-buttons o-buttons--primary	o-buttons--inverse" type="submit">Let&apos;s get started</button>
+
+	</form>
+</div>

--- a/demos/src/inverse.scss
+++ b/demos/src/inverse.scss
@@ -1,5 +1,7 @@
 @import "./demo";
 
 body {
-	background: oColorsByName('slate');
+	// This is the slate colour in master and internal
+	// We hardcode the value because the whitelabel palette does not contain slate.
+	background: #262a33;
 }

--- a/demos/src/inverse.scss
+++ b/demos/src/inverse.scss
@@ -1,7 +1,10 @@
 @import "./demo";
 
 body {
-	// This is the slate colour in master and internal
-	// We hardcode the value because the whitelabel palette does not contain slate.
-	background: #262a33;
+	// slate is in the master and internal brand palette
+	background: if(
+		index(('master', 'internal'), oBrandGetCurrentBrand()) != null,
+		oColorsByName('slate'),
+		oColorsByName('black')
+	);
 }

--- a/origami.json
+++ b/origami.json
@@ -40,7 +40,16 @@
 			"title": "Inverse Form",
 			"template": "/demos/src/inverse-form.mustache",
 			"description": "Inverse form",
-			"sass": "demos/src/inverse.scss"
+			"sass": "demos/src/inverse.scss",
+			"brands": ["master", "internal"]
+		},
+		{
+			"name": "inverse-form-whitelabel",
+			"title": "Inverse Form",
+			"template": "/demos/src/inverse-form-whitelabel.mustache",
+			"description": "Inverse form",
+			"sass": "demos/src/inverse.scss",
+			"brands": ["master", "internal", "whitelabel"]
 		},
 		{
 			"name": "pseudo-radio-links",

--- a/origami.json
+++ b/origami.json
@@ -49,7 +49,7 @@
 			"template": "/demos/src/inverse-form-whitelabel.mustache",
 			"description": "Inverse form",
 			"sass": "demos/src/inverse.scss",
-			"brands": ["master", "internal", "whitelabel"]
+			"brands": ["whitelabel"]
 		},
 		{
 			"name": "pseudo-radio-links",

--- a/src/js/error-summary.js
+++ b/src/js/error-summary.js
@@ -20,6 +20,8 @@ class ErrorSummary {
 		const hasAnInverseField = elements.some(elem => {
 			if (elem.field) {
 				return elem.field.classList.contains('o-forms-field--inverse');
+			} else {
+				return false;
 			}
 		});
 		this.inverse = hasAnInverseField;

--- a/src/js/error-summary.js
+++ b/src/js/error-summary.js
@@ -17,6 +17,12 @@ class ErrorSummary {
 	*/
 	constructor(elements) {
 		this.elements = elements;
+		const hasAnInverseField = elements.some(elem => {
+			if (elem.field) {
+				return elem.field.classList.contains('o-forms-field--inverse');
+			}
+		});
+		this.inverse = hasAnInverseField;
 		this.invalidInputs = [];
 
 		return this.createSummary();
@@ -30,6 +36,9 @@ class ErrorSummary {
 
 		const div = document.createElement('div');
 		div.classList.add('o-forms__error-summary');
+		if (this.inverse) {
+			div.classList.add('o-forms__error-summary--inverse');
+		}
 		div.setAttribute('aria-labelledby', 'error-summary');
 		div.setAttribute('role', 'alert');
 		div.innerHTML = '<h4 class="o-forms__error-summary__heading" id="error-summary">There is a problem</h4>';

--- a/src/scss/modifiers/_inverse.scss
+++ b/src/scss/modifiers/_inverse.scss
@@ -71,6 +71,8 @@
 			}
 
 			.o-forms__error-summary__list {
+				color: oColorsByName('white');
+
 				a {
 					color: oColorsByName('white');
 					border-bottom: 1px solid _oFormsGet('invalid-base-inverse');

--- a/src/scss/shared/_brand.scss
+++ b/src/scss/shared/_brand.scss
@@ -72,7 +72,10 @@ $_o-forms-shared-brand-config: (
 			invalid-base: oColorsByName('crimson'),
 			invalid-base-inverse: oColorsByName('white'),
 			invalid-base-color-inverse: oColorsByName('black'),
-			valid-base: oColorsByName('jade')
+			invalid-base-border-inverse: oColorsByName('crimson'),
+			valid-base: oColorsByName('jade'),
+			error-summary-background-inverse: rgba(oColorsByName('crimson'), 0.11),
+			error-summary-border-inverse: oColorsByName('crimson'),
 		)),
 		'supports-variants': ()
 	));


### PR DESCRIPTION
Currently the demo for inverse fails for whitelabel as it is using `slate` colour which does not exist in the whitelabel colour palette. I've switched to a hardcoded value of `slate` to make it work.

This also updates the error states in whitelabel's inverse mode to match the new design used in internal and master brand

![image](https://user-images.githubusercontent.com/1569131/101164492-fc0b6c00-362c-11eb-9755-8cdb6eef7139.png)
