### PR TITLE
Allow multi-line box-style radio button copy, making them taller.

### DIFF
--- a/src/scss/_radio-box.scss
+++ b/src/scss/_radio-box.scss
@@ -25,12 +25,13 @@
 
 			.o-forms-input__label {
 				box-sizing: border-box;
-				display: inline-block;
-				max-height: $_o-forms-spacing-controls;
 				padding: $_o-forms-spacing-one $_o-forms-spacing-two;
 				transition: 0.3s background-color, 0.15s color ease-out;
-				white-space: nowrap;
 				width: 100%;
+				height: 100%;
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
 			}
 		}
 
@@ -62,11 +63,6 @@
 		.o-forms-input__state {
 			position: relative;
 			margin-bottom: -($_o-forms-spacing-five + $_o-forms-spacing-half);
-		}
-
-		.o-forms-input__error {
-			margin-top: 0;
-			margin-bottom: -$_o-forms-spacing-four;
 		}
 	}
 }

--- a/src/scss/shared/_control-inputs.scss
+++ b/src/scss/shared/_control-inputs.scss
@@ -43,9 +43,9 @@
 /// @access private
 /// @output Shared styles for box-style radio buttons and anchor controls
 @mixin _oFormsControlsBoxBase {
-	display: inline-block;
+	display: inline-flex;
+	flex-grow: 1;
 	cursor: pointer;
-	float: left;
 	margin: 0;
 	min-height: $_o-forms-spacing-seven;
 	min-width: 8ch;
@@ -62,7 +62,8 @@
 	);
 	box-sizing: border-box;
 	border: $_o-forms-border;
-	display: inline-block;
-	padding: $_o-forms-spacing-half;
+	display: inline-flex;
+	flex-wrap: wrap;
 	text-align: center;
+	padding: $_o-forms-spacing-half;
 }


### PR DESCRIPTION
By default box style radio buttons maintain a single line of copy and boxes 
wrap, maintaining the single line of copy, as a last resort to prevent 
overflow. The wrapping behaviour is maintained here but this commit 
makes box style radio buttons more flexible to allow for taller, 
multi-line radio buttons.

before/after with non-selected box hovered:
![Screenshot 2021-03-08 at 14 12 32](https://user-images.githubusercontent.com/10405691/110332574-67901b80-8018-11eb-9094-715d503c0a7f.png)
![Screenshot 2021-03-08 at 14 12 39](https://user-images.githubusercontent.com/10405691/110332583-6a8b0c00-8018-11eb-8398-fea998067727.png)

Excess white-space is removed incidentally as part of this change
which allows radio-box specific error message styles to be removed.
Elements below a box style radio button, such as subsequent input,
now appear closer — consistent with the spacing between other form
elements.

before/after
![Screenshot 2021-03-08 at 14 09 05](https://user-images.githubusercontent.com/10405691/110332152-e33d9880-8017-11eb-8dfb-520d28b7bff5.png)
![Screenshot 2021-03-08 at 14 08 51](https://user-images.githubusercontent.com/10405691/110332156-e3d62f00-8017-11eb-8a9a-9de3f922a8ee.png)

before/after
![Screenshot 2021-03-08 at 14 09 57](https://user-images.githubusercontent.com/10405691/110332246-036d5780-8018-11eb-97a3-19d239e78d3f.png)
![Screenshot 2021-03-08 at 14 10 38](https://user-images.githubusercontent.com/10405691/110332314-15e79100-8018-11eb-8810-b023d06d2a55.png)

These changes came about for the payments page of ft.com, where box
inputs are being used more like tabs to alter inputs later in the
form. Using `o-tabs` would not be semantically correct, however
multiline box radio buttons do work visually and semantically.
As designs for this page are still a work in progress this commit
is limited to making box style radio buttons more flexible rather
than documenting a new pattern, or changing existing patterns.