### PR TITLE
Add styling for file inputs using the new `::file-selector-button` pseudo-element

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ To create a text input use a [single input](#single-input-fields) field structur
 </label>
 ```
 
+#### File input
+
+To create a file input use a [single input](#single-input-fields) field structure, with an `o-forms-input--file` modifier class on the `o-forms-input` element and an input type of `type="file"`.
+
+```html
+<label class="o-forms-field">
+	<span class="o-forms-title">
+		<span class="o-forms-title__main">Label for input here</span>
+	</span>
+
+	<span class="o-forms-input o-forms-input--file">
+		<input type="file" name="file-example" value>
+	</span>
+</label>
+```
+
 #### Password input
 
 To create a password input use a [single input](#single-input-fields) field structure, with an `o-forms-input--password` modifier class on the `o-forms-input` element and an input type of `type="password"`.
@@ -652,6 +668,7 @@ The `$opts` map accepts two lists with the following options:
 - `'elements'`:
 	- `'checkbox'`
 	- `'date'`
+	- `'file'`
 	- `'password'`
 	- `'pseudo-radio-link'`
 	- `'radio-round'`

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   ],
   "dependencies": {
     "o-brand": "^3.2.5",
+    "o-buttons": "^6.2.0",
     "o-colors": "^5.0.0",
     "o-grid": "^5.0.0",
     "o-icons": "^6.0.0",

--- a/demos/src/data/file-input.json
+++ b/demos/src/data/file-input.json
@@ -1,0 +1,42 @@
+{
+	"variants": [
+		{
+			"optional": true,
+			"title": {
+				"main": "Optional file input",
+				"prompt": "Optional prompt file"
+			},
+			"input": {
+				"type": "file"
+			}
+		},
+		{
+			"title": {
+				"main": "File input with a valid entry"
+			},
+			"input": {
+				"type": "file",
+				"modifiers": [ "valid" ]
+			}
+		},
+		{
+			"title": {
+				"main": "File input with an invalid entry"
+			},
+			"input": {
+				"type": "file",
+				"modifiers": [ "invalid" ],
+				"error": "Please select a file"
+			}
+		},
+		{
+			"inline-field": true,
+			"title": {
+				"main": "Inline file input"
+			},
+			"input": {
+				"type": "file"
+			}
+		}
+	]
+}

--- a/demos/src/data/pa11y.json
+++ b/demos/src/data/pa11y.json
@@ -405,6 +405,15 @@
 			{
 				"textInput": true,
 				"title": {
+					"main": "File input"
+				},
+				"input": {
+					"type": "file"
+				}
+			},
+			{
+				"textInput": true,
+				"title": {
 					"main": "Password input"
 				},
 				"input": {

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,4 +1,3 @@
-$o-forms-is-silent: false;
 @import "./../../main";
 
 body {

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -45,3 +45,5 @@ $icon-list: ('grid', 'list');
 	$icons: $icon-list,
 	$theme: $custom-theme
 );
+
+@include oForms();

--- a/demos/src/file-input-field.mustache
+++ b/demos/src/file-input-field.mustache
@@ -1,0 +1,21 @@
+{{#variants}}
+	<label class="o-forms-field{{#inline-field}} o-forms-field--inline{{/inline-field}}{{#optional}} o-forms-field--optional{{/optional}}">
+
+		<span class="o-forms-title{{#title.modifiers}} o-forms-title--{{.}}{{/title.modifiers}}">
+			<span class="o-forms-title__main">{{title.main}}</span>
+			{{#title.prompt}}<span class="o-forms-title__prompt">{{.}}</span>{{/title.prompt}}
+		</span>
+
+		<span class="o-forms-input o-forms-input--{{input.type}}{{#input.modifiers}} o-forms-input--{{.}}{{/input.modifiers}}">
+
+			<input
+				type="{{input.type}}"
+				name="text"
+				value="{{input.value}}"
+			>
+
+			{{#input.error}}<span class="o-forms-input__error">{{.}}</span>{{/input.error}}
+		</span>
+
+	</label>
+{{/variants}}

--- a/demos/src/inverse-form.mustache
+++ b/demos/src/inverse-form.mustache
@@ -103,6 +103,17 @@
 			</span>
 		</div>
 
+		<label class="o-forms-field o-forms-field--optional o-forms-field--inverse">
+			<span class="o-forms-title">
+				<span class="o-forms-title__main">Optional file input</span>
+				<span class="o-forms-title__prompt">Optional prompt file</span>
+			</span>
+
+			<span class="o-forms-input o-forms-input--file">
+				<input type="file" name="optional" value>
+			</span>
+		</label>
+
 		<input id="hidden-demo" name="hidden-demo" type="hidden" value="123">
 
 		<button class="o-buttons o-buttons--primary	" type="submit">Let&apos;s get started</button>

--- a/main.scss
+++ b/main.scss
@@ -54,6 +54,7 @@
 	$suffix: index($features, 'suffix');
 	$radio-round: index($elements, 'radio-round');
 	$radio-box: index($elements, 'radio-box');
+	$file: index($elements, 'file');
 
 	@include _oFormsBase();
 
@@ -74,7 +75,7 @@
 		);
 	}
 
-	@if index($elements, 'file') {
+	@if $file {
 		@include _oFormsFileInput();
 	}
 
@@ -124,7 +125,7 @@
 	}
 
 	@if $inverse {
-		@include _oFormsInverse($error-summary, $radio-box);
+		@include _oFormsInverse($error-summary, $radio-box, $file);
 	}
 
 	@if $state {

--- a/main.scss
+++ b/main.scss
@@ -20,6 +20,7 @@
 	'elements': (
 		'checkbox',
 		'date',
+		'file',
 		'password',
 		'pseudo-radio-link',
 		'radio-round',
@@ -71,6 +72,10 @@
 		@include _oFormsDate(
 			$disabled
 		);
+	}
+
+	@if index($elements, 'file') {
+		@include _oFormsFileInput();
 	}
 
 	@if $radio-round {

--- a/origami.json
+++ b/origami.json
@@ -1,6 +1,6 @@
 {
 	"description": "This component provides responsive styling for form fields and inputs. It provides validation and error handling for forms, as well.",
-	"keywords": [ "form", "input", "field", "fieldset", "submit", "file" ],
+	"keywords": [ "form", "input", "field", "fieldset", "submit", "file", "upload" ],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": 1,

--- a/origami.json
+++ b/origami.json
@@ -109,6 +109,13 @@
 			"data": "/demos/src/data/text-input.json"
 		},
 		{
+			"name": "file-input",
+			"title": "File input",
+			"template": "/demos/src/file-input-field.mustache",
+			"description": "Regular file input",
+			"data": "/demos/src/data/file-input.json"
+		},
+		{
 			"name": "text-area",
 			"title": "Text Area",
 			"template": "/demos/src/single-input-field.mustache",

--- a/origami.json
+++ b/origami.json
@@ -1,6 +1,6 @@
 {
 	"description": "This component provides responsive styling for form fields and inputs. It provides validation and error handling for forms, as well.",
-	"keywords": [ "form", "input", "field", "fieldset", "submit" ],
+	"keywords": [ "form", "input", "field", "fieldset", "submit", "file" ],
 	"origamiType": "module",
 	"origamiCategory": "components",
 	"origamiVersion": 1,

--- a/src/scss/_file-input.scss
+++ b/src/scss/_file-input.scss
@@ -1,0 +1,11 @@
+/// @access private
+/// @output Styling for file inputs
+@mixin _oFormsFileInput(
+) {
+
+	.o-forms-input--file ::file-selector-button {
+		@include oButtonsContent($opts: (
+			'type': 'primary'
+		));
+	}
+}

--- a/src/scss/_file-input.scss
+++ b/src/scss/_file-input.scss
@@ -7,5 +7,6 @@
 		@include oButtonsContent($opts: (
 			'type': 'primary'
 		));
+		margin-right: oSpacingByName('s1');
 	}
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,8 +1,9 @@
+@import 'o-buttons/main';
 // Styles shared between all input types
 @import './shared/brand';
 @import './shared/variables';
-@import './shared/base'; 
-@import './shared/control-inputs'; // grouped inputs (e.g. radio/checkboxes) 
+@import './shared/base';
+@import './shared/control-inputs'; // grouped inputs (e.g. radio/checkboxes)
 @import './shared/error-summary';
 @import './shared/inline';
 @import './shared/single-inputs'; // individual inputs (e.g. text, select)
@@ -11,6 +12,7 @@
 // Input-type specific styles
 @import './checkbox';
 @import './date';
+@import './file-input';
 @import './pseudo-radio-link';
 @import './radio-box';
 @import './radio-round';

--- a/src/scss/modifiers/_inverse.scss
+++ b/src/scss/modifiers/_inverse.scss
@@ -1,8 +1,9 @@
 /// @access private
 /// @param {Boolean} $error-summary Whether to output inverse error summary styling
 /// @param {Boolean} $radio Whether to output inverse radio input styling
+/// @param {Boolean} $file Whether to output inverse file input styling
 /// @output styles for inverse toggle based on a checkbox input
-@mixin _oFormsInverse($error-summary: null, $radio: null) {
+@mixin _oFormsInverse($error-summary: null, $radio: null, $file: null) {
 	.o-forms-field--inverse {
 		color: _oFormsGet('toggle-inverse');
 
@@ -55,6 +56,15 @@
 			}
 			.o-forms-input--radio-box__container {
 				background-color: oColorsByName('white');
+			}
+		}
+
+		@if $file {
+			.o-forms-input--file ::file-selector-button {
+				@include oButtonsContent($opts: (
+					'type': 'primary',
+					'themes': ('inverse')
+				));
 			}
 		}
 	}

--- a/src/scss/modifiers/_inverse.scss
+++ b/src/scss/modifiers/_inverse.scss
@@ -64,7 +64,7 @@
 				@include oButtonsContent($opts: (
 					'type': 'primary',
 					'theme': 'inverse'
-				));
+				), $include-base-styles: false);
 			}
 		}
 	}

--- a/src/scss/modifiers/_inverse.scss
+++ b/src/scss/modifiers/_inverse.scss
@@ -63,7 +63,7 @@
 			.o-forms-input--file ::file-selector-button {
 				@include oButtonsContent($opts: (
 					'type': 'primary',
-					'themes': ('inverse')
+					'theme': 'inverse'
 				));
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/Financial-Times/o-forms/issues/199

You can view the demos here: https://o-forms-files-nw7lggciez3va1gz.herokuapp.com/

![image](https://user-images.githubusercontent.com/1569131/115256659-5530f380-a127-11eb-80f5-6bf8275060b2.png)

![image](https://user-images.githubusercontent.com/1569131/115256685-5c580180-a127-11eb-9b17-9c920be4963a.png)



- [x] Add an implementation for the "inverse" theme
- [x] Add this to the pa11y demo
- [x] Update readme with new input type