### PR TITLE
update colour for valid input modifier to comply with contrast requirements

### DIFF
--- a/src/scss/shared/_brand.scss
+++ b/src/scss/shared/_brand.scss
@@ -75,7 +75,7 @@ $_o-forms-shared-brand-config: (
 			invalid-base-inverse: oColorsByName('white'),
 			invalid-base-color-inverse: oColorsByName('black'),
 			invalid-base-border-inverse: oColorsByName('crimson'),
-			valid-base: oColorsByName('jade'),
+			valid-base: oColorsMix('jade', 'black', 80),
 			error-summary-background-inverse: rgba(oColorsByName('crimson'), 0.11),
 			error-summary-border-inverse: oColorsByName('crimson'),
 		)),


### PR DESCRIPTION
The current colour contrast is 3.71
The proposed colour, which is the same as master brand, gives a contrast of 5.45 - which exceeds the contrast requirements

I found this during the origami 2.0 component migration