### PR TITLE
Update README/MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -69,7 +69,7 @@ The customisation mixin outputs a custom modifier, and can be applied as follows
 // the custom class modifier will be: .o-forms-input--my-theme
 ```
 
-The markup has been changed entirely to accomodate the following structure:
+The markup has been changed entirely to accommodate the following structure:
 ```
 ┌— field container (.o-forms-field) —————┐
 |      (one of div or label)             |
@@ -110,6 +110,9 @@ The root `o-forms` class is no longer used. Instead, there are modifiers for eac
 	- `.o-forms-input--toggle`
 	- `.o-forms-input--valid`
 
+Unlike with the previous `o-forms` class no `max-width` is set, as this was often overridden by projects based on context. Place your form field elements within a containing element or set your own `max-width`.
+
+Note that in some cases the above modifiers must be used to recreate previously default behaviour. The inline input titles now require the `o-forms-title--vertical-center` class to vertically with the input, where the label is short and prompt text has not been provided.
 
 The JavaScript for `o-forms` now accepts two options:
 - `useBrowserValidation`: whether to use the browsers validtion and error messages. Defaults to `false`

--- a/README.md
+++ b/README.md
@@ -539,9 +539,9 @@ By default the inline label and input will be a set width to ensure multiple inl
 ```diff
 -<label class="o-forms-field">
 +<label class="o-forms-field o-forms-field--inline">
-	<span class="o-forms-title">
--		<span class="o-forms-title__main">short label</span>
-+		<span class="o-forms-title__main o-forms-title--shrink">short label</span>
+-	<span class="o-forms-title o-forms-title--shrink">
++	<span class="o-forms-title o-forms-title--shrink">
+		<span class="o-forms-title__main">short label</span>
 	</span>
 
 	<span class="o-forms-input o-forms-input--text">


### PR DESCRIPTION
Based on user feedback/questions.

________

https://financialtimes.slack.com/archives/C02FU5ARJ/p1627311495242300?thread_ts=1627304115.241200&cid=C02FU5ARJ

Hey, I think I’ve figured out what’s happened here, these visual issues are due to changes we need to make for the v6->v7 migration.

If I’m not mistaken:
1. bigger (full width): v7 removed max-width from form fields because we found users often need to override that based on context. To shrink it back up either set a max-width on the field or place it within a containing element that has a max-width set.
2. spaced out: the label is set to a percentage width so that multiple fields with an inline label line up. As this field is really wide (because of 1) and the label text is quite short they appear spread out. You don’t have a form of multiple fields though so can add o-forms-title--shrink to the title element.
3. vertical alignment: it’s not vertically aligned by default to account for long labels / prompt information. Since you have a short label you can apply o-forms-title--vertical-center to the title element.